### PR TITLE
these owners aren't WordPress owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @actions/actions-runtime


### PR DESCRIPTION
I think it is best to wait on setting Code Owners until this is a bit more mature and when that does happen, it should be a WordPress group. 