### PR TITLE
Change `Co-Authored-By:` casing.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37853,7 +37853,7 @@ async function getContributorsList() {
 						return;
 					}
 
-					return `Co-authored-by: ${username} <${dotOrg}@git.wordpress.org>`;
+					return `Co-Authored-By: ${username} <${dotOrg}@git.wordpress.org>`;
 				})
 				.filter((el) => el)
 				.join("\n")

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -210,7 +210,7 @@ export async function getContributorsList() {
 						return;
 					}
 
-					return `Co-authored-by: ${username} <${dotOrg}@git.wordpress.org>`;
+					return `Co-Authored-By: ${username} <${dotOrg}@git.wordpress.org>`;
 				})
 				.filter((el) => el)
 				.join("\n")


### PR DESCRIPTION
It seems that `Co-Authored-By:` needs to be capitalized as such. In the initial version it was set to `Co-authored-by:`, and pasting into the merge commit message did not result in properly sharing attribution.

- Example [commit not showing attribution](https://github.com/WordPress/props-bot-action/commit/fd418b6ba3764b81a92b2247edfe8d8a8d2b3a89).
- Example [commit showing proper attribution](https://github.com/WordPress/props-bot-action/commit/ffa7b90b981663267cdf78757913c72badfd62ec) (co-authored trailer added using GitHub Desktop).

The casing is the only difference. Let's see if proper casing resolves the issue.