### PR TITLE
Don't display section headers

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37828,38 +37828,33 @@ async function getContributorsList() {
 				return [];
 			}
 
-			// Add a header for each section.
-			const header =
-        "# " + priority.replace(/^./, (char) => char.toUpperCase()) + "\n";
-
 			// Generate each props entry, and join them into a single string.
 			return (
-				header +
-			[...contributors[priority]]
-				.map((username) => {
-					if ('unlinked' == priority) {
-						core.debug( 'Unlinked contributor: ' + username );
-						return `Unlinked contributor: ${username}`;
-					}
+				[...contributors[priority]]
+					.map((username) => {
+						if ('unlinked' == priority) {
+							core.debug( 'Unlinked contributor: ' + username );
+							return `Unlinked contributor: ${username}`;
+						}
 
-					const { dotOrg } = userData[username];
-					if (
-						!Object.prototype.hasOwnProperty.call(
-							userData[username],
-							"dotOrg"
-						)
-					) {
-						contributors.unlinked.add(username);
-						return;
-					}
+						const { dotOrg } = userData[username];
+						if (
+							!Object.prototype.hasOwnProperty.call(
+								userData[username],
+								"dotOrg"
+							)
+						) {
+							contributors.unlinked.add(username);
+							return;
+						}
 
-					return `Co-Authored-By: ${username} <${dotOrg}@git.wordpress.org>`;
-				})
-				.filter((el) => el)
-				.join("\n")
+						return `Co-Authored-By: ${username} <${dotOrg}@git.wordpress.org>`;
+					})
+					.filter((el) => el)
+					.join("\n")
 			);
 		})
-		.join("\n\n");
+		.join("\n");
 }
 
 /**

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -185,38 +185,33 @@ export async function getContributorsList() {
 				return [];
 			}
 
-			// Add a header for each section.
-			const header =
-        "# " + priority.replace(/^./, (char) => char.toUpperCase()) + "\n";
-
 			// Generate each props entry, and join them into a single string.
 			return (
-				header +
-			[...contributors[priority]]
-				.map((username) => {
-					if ('unlinked' == priority) {
-						core.debug( 'Unlinked contributor: ' + username );
-						return `Unlinked contributor: ${username}`;
-					}
+				[...contributors[priority]]
+					.map((username) => {
+						if ('unlinked' == priority) {
+							core.debug( 'Unlinked contributor: ' + username );
+							return `Unlinked contributor: ${username}`;
+						}
 
-					const { dotOrg } = userData[username];
-					if (
-						!Object.prototype.hasOwnProperty.call(
-							userData[username],
-							"dotOrg"
-						)
-					) {
-						contributors.unlinked.add(username);
-						return;
-					}
+						const { dotOrg } = userData[username];
+						if (
+							!Object.prototype.hasOwnProperty.call(
+								userData[username],
+								"dotOrg"
+							)
+						) {
+							contributors.unlinked.add(username);
+							return;
+						}
 
-					return `Co-Authored-By: ${username} <${dotOrg}@git.wordpress.org>`;
-				})
-				.filter((el) => el)
-				.join("\n")
+						return `Co-Authored-By: ${username} <${dotOrg}@git.wordpress.org>`;
+					})
+					.filter((el) => el)
+					.join("\n")
 			);
 		})
-		.join("\n\n");
+		.join("\n");
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes the section headers and ensures there are no empty lines between `Co-authored-by` trailers (they're not allowed).

Fixes #17.