### PR TITLE
Remove `push` event from test workflow

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,10 +1,6 @@
 name: Test the Action
 
 on:
-  push:
-    branches:
-      - 'trunk'
-      - 'releases/*'
   pull_request:
   pull_request_review:
     types:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The GitHub Actions workflow that tests the action itself should not run on `push`. The Action can only be run in the context of a pull request.