### PR TITLE
Change from title casing to sentence casing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37877,7 +37877,7 @@ async function getContributorsList() {
 						return;
 					}
 
-					return contributorLists['coAuthored'].push( `Co-Authored-By: ${username} <${dotOrg}@git.wordpress.org>` );
+					return contributorLists['coAuthored'].push( `Co-authored-by: ${username} <${dotOrg}@git.wordpress.org>` );
 				})
 				.filter((el) => el);
 		});

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -212,7 +212,7 @@ export async function getContributorsList() {
 						return;
 					}
 
-					return contributorLists['coAuthored'].push( `Co-Authored-By: ${username} <${dotOrg}@git.wordpress.org>` );
+					return contributorLists['coAuthored'].push( `Co-authored-by: ${username} <${dotOrg}@git.wordpress.org>` );
 				})
 				.filter((el) => el);
 		});


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
This changes the casing for the co-authored trailer from sentence to title casing.

## Why?
In #28, the casing for `Co-authored-by` was changed from sentence to title. At the time it was done to see if the casing was the reason why the trailers were not being picked up. It turned out there were other issues causing this.

After some more research, it seems that most tools use sentence casing for the trailer rather than title casing, including suggestions for the trailer in the GitHub suggested merge commit message. This changes the casing used for consistency.