### PR TITLE
Remove version from example.

### DIFF
--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Gather a list of contributors
-        uses: WordPress/props-bot-action@v1
+        uses: WordPress/props-bot-action@trunk
 
       - name: Remove the props-bot label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1


### PR DESCRIPTION
It seems there are still a few steps needed to make this work. For the initial release, it's fine to use `trunk`. It will give us more testing.
