### PR TITLE
Tell Core Committers to include the list and not assume it's complete.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35429,9 +35429,9 @@ class GitHub {
 		}
 
 		commentMessage += "## Core SVN\n\n" +
-		"If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
+		"If you're a Core Committer, make sure these usernames are included in the props list when committing to `wordpress-develop` in SVN:\n" +
 		"```\n" +
-		"Props: " + contributorsList['svn'].join(', ') + "." +
+		contributorsList['svn'].join(', ') + "." +
 		"\n```\n\n" +
 		"## GitHub Merge commits\n\n" +
 		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +

--- a/dist/index.js
+++ b/dist/index.js
@@ -35431,7 +35431,7 @@ class GitHub {
 		commentMessage += "## Core SVN\n\n" +
 		"Core Committers: Use this line as a base for the props when committing in SVN:\n" +
 		"```\n" +
-		"Props: " + contributorsList['svn'].join(', ') + "." +
+		"Props " + contributorsList['svn'].join(', ') + "." +
 		"\n```\n\n" +
 		"## GitHub Merge commits\n\n" +
 		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +

--- a/dist/index.js
+++ b/dist/index.js
@@ -35429,9 +35429,9 @@ class GitHub {
 		}
 
 		commentMessage += "## Core SVN\n\n" +
-		"If you're a Core Committer, make sure these usernames are included in the props list when committing to `wordpress-develop` in SVN:\n" +
+		"Core Committers: Use this line as a base for the props when committing in SVN:\n" +
 		"```\n" +
-		contributorsList['svn'].join(', ') + "." +
+		"Props: " + contributorsList['svn'].join(', ') + "." +
 		"\n```\n\n" +
 		"## GitHub Merge commits\n\n" +
 		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +

--- a/src/github.js
+++ b/src/github.js
@@ -147,7 +147,7 @@ export default class GitHub {
 		commentMessage += "## Core SVN\n\n" +
 		"Core Committers: Use this line as a base for the props when committing in SVN:\n" +
 		"```\n" +
-		"Props: " + contributorsList['svn'].join(', ') + "." +
+		"Props " + contributorsList['svn'].join(', ') + "." +
 		"\n```\n\n" +
 		"## GitHub Merge commits\n\n" +
 		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +

--- a/src/github.js
+++ b/src/github.js
@@ -145,9 +145,9 @@ export default class GitHub {
 		}
 
 		commentMessage += "## Core SVN\n\n" +
-		"If you're a Core Committer, make sure these usernames are included in the props list when committing to `wordpress-develop` in SVN:\n" +
+		"Core Committers: Use this line as a base for the props when committing in SVN:\n" +
 		"```\n" +
-		contributorsList['svn'].join(', ') + "." +
+		"Props: " + contributorsList['svn'].join(', ') + "." +
 		"\n```\n\n" +
 		"## GitHub Merge commits\n\n" +
 		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +

--- a/src/github.js
+++ b/src/github.js
@@ -145,9 +145,9 @@ export default class GitHub {
 		}
 
 		commentMessage += "## Core SVN\n\n" +
-		"If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
+		"If you're a Core Committer, make sure these usernames are included in the props list when committing to `wordpress-develop` in SVN:\n" +
 		"```\n" +
-		"Props: " + contributorsList['svn'].join(', ') + "." +
+		contributorsList['svn'].join(', ') + "." +
 		"\n```\n\n" +
 		"## GitHub Merge commits\n\n" +
 		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +


### PR DESCRIPTION
## What?
Tell Core Committers to make sure the usernames are _included_ in the props list, to avoid missing props for Trac contributions if the committer assumes its GitHub/Trac-complete.

## Why?
Props Bot currently handles interactions with a PR/related issues. Since it doesn't include Trac contributions yet, the props list it provides is likely incomplete.