### PR TITLE
Add pagination to comment lookup query

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35460,6 +35460,7 @@ class GitHub {
 					currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
 				) {
 					commentId = currentComment.id;
+					break;
 				}
 			}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -35450,14 +35450,21 @@ class GitHub {
 			body: commentMessage,
 		};
 
-		const comments = (await this.octokit.rest.issues.listComments(commentInfo))
-			.data;
-		for (const currentComment of comments) {
-			if (
-				currentComment.user.type === "Bot" &&
-				currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
-			) {
-				commentId = currentComment.id;
+		for await (const response of this.octokit.paginate.iterator(
+			this.octokit.rest.issues.listForRepo,
+			commentInfo
+		)) {
+			for (const currentComment of response.data) {
+				if (
+					currentComment.user.type === "Bot" &&
+					currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
+				) {
+					commentId = currentComment.id;
+					break;
+				}
+			}
+
+			if ( commentId ) {
 				break;
 			}
 		}

--- a/dist/index.js
+++ b/dist/index.js
@@ -35486,7 +35486,7 @@ class GitHub {
 
 		// No previous or edit comment failed.
 		if (!commentId) {
-			core.info("Creating new comment");
+			core.info("No previous comment found. Creating a new one.");
 			try {
 				await this.octokit.rest.issues.createComment(comment);
 			} catch (e) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -35469,6 +35469,9 @@ class GitHub {
 			}
 		}
 
+		core.info( 'Previous comment ID found: ' + commentId );
+		return;
+
 		if (commentId) {
 			core.info(`Updating previous comment #${commentId}`);
 			try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -35451,7 +35451,7 @@ class GitHub {
 		};
 
 		for await (const response of this.octokit.paginate.iterator(
-			this.octokit.rest.issues.listForRepo,
+			this.octokit.rest.issues.listComments,
 			commentInfo
 		)) {
 			console.debug( response );

--- a/dist/index.js
+++ b/dist/index.js
@@ -35415,9 +35415,9 @@ class GitHub {
 
 		let commentId;
 		const commentInfo = {
-			owner: 'WordPress',
-			repo: 'gutenberg',
-			issue_number: 57841,
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			issue_number: prNumber,
 		};
 
 		let commentMessage = "The following accounts have interacted with this PR and/or linked issues. I will continue to update these lists as activity occurs. You can also manually ask me to refresh this list by adding the `props-bot` label.\n\n";
@@ -35474,8 +35474,7 @@ class GitHub {
 
 			try {
 				await this.octokit.rest.issues.updateComment({
-					owner: context.repo.owner,
-					repo: context.repo.repo,
+					...context.repo,
 					comment_id: commentId,
 					body: comment.body,
 				});

--- a/dist/index.js
+++ b/dist/index.js
@@ -35454,8 +35454,6 @@ class GitHub {
 			this.octokit.rest.issues.listComments,
 			commentInfo
 		)) {
-			console.debug( response );
-			core.info( response );
 			for (const currentComment of response.data) {
 				if (
 					currentComment.user.type === "Bot" &&
@@ -35467,16 +35465,18 @@ class GitHub {
 				}
 			}
 
-			if ( commentId ) {
+			if (commentId) {
 				break;
 			}
 		}
 
 		if (commentId) {
 			core.info(`Updating previous comment #${commentId}`);
+			return;
 			try {
 				await this.octokit.rest.issues.updateComment({
-					...context.repo,
+					owner: context.repo.owner,
+					repo: context.repo.repo,
 					comment_id: commentId,
 					body: comment.body,
 				});

--- a/dist/index.js
+++ b/dist/index.js
@@ -35415,9 +35415,9 @@ class GitHub {
 
 		let commentId;
 		const commentInfo = {
-			owner: context.repo.owner,
-			repo: context.repo.repo,
-			issue_number: prNumber,
+			owner: 'WordPress',
+			repo: 'gutenberg',
+			issue_number: 57841,
 		};
 
 		let commentMessage = "The following accounts have interacted with this PR and/or linked issues. I will continue to update these lists as activity occurs. You can also manually ask me to refresh this list by adding the `props-bot` label.\n\n";

--- a/dist/index.js
+++ b/dist/index.js
@@ -35454,6 +35454,8 @@ class GitHub {
 			this.octokit.rest.issues.listForRepo,
 			commentInfo
 		)) {
+			console.debug( response );
+			core.info( response );
 			for (const currentComment of response.data) {
 				if (
 					currentComment.user.type === "Bot" &&

--- a/dist/index.js
+++ b/dist/index.js
@@ -35460,7 +35460,8 @@ class GitHub {
 					currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
 				) {
 					commentId = currentComment.id;
-					break;
+					core.info( 'Previous comment ID found: ' + commentId );
+					return;
 				}
 			}
 
@@ -35468,9 +35469,6 @@ class GitHub {
 				break;
 			}
 		}
-
-		core.info( 'Previous comment ID found: ' + commentId );
-		return;
 
 		if (commentId) {
 			core.info(`Updating previous comment #${commentId}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -35460,8 +35460,6 @@ class GitHub {
 					currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
 				) {
 					commentId = currentComment.id;
-					core.info( 'Previous comment ID found: ' + commentId );
-					return;
 				}
 			}
 
@@ -35472,7 +35470,7 @@ class GitHub {
 
 		if (commentId) {
 			core.info(`Updating previous comment #${commentId}`);
-			return;
+
 			try {
 				await this.octokit.rest.issues.updateComment({
 					owner: context.repo.owner,

--- a/src/github.js
+++ b/src/github.js
@@ -176,8 +176,6 @@ export default class GitHub {
 					currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
 				) {
 					commentId = currentComment.id;
-					core.info( 'Previous comment ID found: ' + commentId );
-					return;
 				}
 			}
 
@@ -188,7 +186,7 @@ export default class GitHub {
 
 		if (commentId) {
 			core.info(`Updating previous comment #${commentId}`);
-			return;
+
 			try {
 				await this.octokit.rest.issues.updateComment({
 					owner: context.repo.owner,

--- a/src/github.js
+++ b/src/github.js
@@ -176,7 +176,8 @@ export default class GitHub {
 					currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
 				) {
 					commentId = currentComment.id;
-					break;
+					core.info( 'Previous comment ID found: ' + commentId );
+					return;
 				}
 			}
 
@@ -184,9 +185,6 @@ export default class GitHub {
 				break;
 			}
 		}
-
-		core.info( 'Previous comment ID found: ' + commentId );
-		return;
 
 		if (commentId) {
 			core.info(`Updating previous comment #${commentId}`);

--- a/src/github.js
+++ b/src/github.js
@@ -170,8 +170,6 @@ export default class GitHub {
 			this.octokit.rest.issues.listComments,
 			commentInfo
 		)) {
-			console.debug( response );
-			core.info( response );
 			for (const currentComment of response.data) {
 				if (
 					currentComment.user.type === "Bot" &&
@@ -183,16 +181,18 @@ export default class GitHub {
 				}
 			}
 
-			if ( commentId ) {
+			if (commentId) {
 				break;
 			}
 		}
 
 		if (commentId) {
 			core.info(`Updating previous comment #${commentId}`);
+			return;
 			try {
 				await this.octokit.rest.issues.updateComment({
-					...context.repo,
+					owner: context.repo.owner,
+					repo: context.repo.repo,
 					comment_id: commentId,
 					body: comment.body,
 				});

--- a/src/github.js
+++ b/src/github.js
@@ -131,9 +131,9 @@ export default class GitHub {
 
 		let commentId;
 		const commentInfo = {
-			owner: 'WordPress',
-			repo: 'gutenberg',
-			issue_number: 57841,
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			issue_number: prNumber,
 		};
 
 		let commentMessage = "The following accounts have interacted with this PR and/or linked issues. I will continue to update these lists as activity occurs. You can also manually ask me to refresh this list by adding the `props-bot` label.\n\n";
@@ -190,8 +190,7 @@ export default class GitHub {
 
 			try {
 				await this.octokit.rest.issues.updateComment({
-					owner: context.repo.owner,
-					repo: context.repo.repo,
+					...context.repo,
 					comment_id: commentId,
 					body: comment.body,
 				});

--- a/src/github.js
+++ b/src/github.js
@@ -176,6 +176,7 @@ export default class GitHub {
 					currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
 				) {
 					commentId = currentComment.id;
+					break;
 				}
 			}
 

--- a/src/github.js
+++ b/src/github.js
@@ -170,6 +170,8 @@ export default class GitHub {
 			this.octokit.rest.issues.listForRepo,
 			commentInfo
 		)) {
+			console.debug( response );
+			core.info( response );
 			for (const currentComment of response.data) {
 				if (
 					currentComment.user.type === "Bot" &&

--- a/src/github.js
+++ b/src/github.js
@@ -166,14 +166,21 @@ export default class GitHub {
 			body: commentMessage,
 		};
 
-		const comments = (await this.octokit.rest.issues.listComments(commentInfo))
-			.data;
-		for (const currentComment of comments) {
-			if (
-				currentComment.user.type === "Bot" &&
-				currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
-			) {
-				commentId = currentComment.id;
+		for await (const response of this.octokit.paginate.iterator(
+			this.octokit.rest.issues.listForRepo,
+			commentInfo
+		)) {
+			for (const currentComment of response.data) {
+				if (
+					currentComment.user.type === "Bot" &&
+					currentComment.body.includes( 'The following accounts have interacted with this PR and/or linked issues.' )
+				) {
+					commentId = currentComment.id;
+					break;
+				}
+			}
+
+			if ( commentId ) {
 				break;
 			}
 		}

--- a/src/github.js
+++ b/src/github.js
@@ -202,7 +202,7 @@ export default class GitHub {
 
 		// No previous or edit comment failed.
 		if (!commentId) {
-			core.info("Creating new comment");
+			core.info("No previous comment found. Creating a new one.");
 			try {
 				await this.octokit.rest.issues.createComment(comment);
 			} catch (e) {

--- a/src/github.js
+++ b/src/github.js
@@ -131,9 +131,9 @@ export default class GitHub {
 
 		let commentId;
 		const commentInfo = {
-			owner: context.repo.owner,
-			repo: context.repo.repo,
-			issue_number: prNumber,
+			owner: 'WordPress',
+			repo: 'gutenberg',
+			issue_number: 57841,
 		};
 
 		let commentMessage = "The following accounts have interacted with this PR and/or linked issues. I will continue to update these lists as activity occurs. You can also manually ask me to refresh this list by adding the `props-bot` label.\n\n";

--- a/src/github.js
+++ b/src/github.js
@@ -185,6 +185,9 @@ export default class GitHub {
 			}
 		}
 
+		core.info( 'Previous comment ID found: ' + commentId );
+		return;
+
 		if (commentId) {
 			core.info(`Updating previous comment #${commentId}`);
 			try {

--- a/src/github.js
+++ b/src/github.js
@@ -167,7 +167,7 @@ export default class GitHub {
 		};
 
 		for await (const response of this.octokit.paginate.iterator(
-			this.octokit.rest.issues.listForRepo,
+			this.octokit.rest.issues.listComments,
 			commentInfo
 		)) {
 			console.debug( response );


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
This adds pagination the the queries attempting to locate a previous comment from the bot to update.

## Why?
The maximum number of items that can be returned by GitHub APIs is 100. When pull requests have a long history before receiving a comment from the bot, the bot will be unable to locate a previous comment and will continuously add new ones.

This fixes #54.
