### PR TITLE
Exclude Dependabot from props lists

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37903,7 +37903,7 @@ async function getContributorsList() {
  * @return {boolean} true if the username should be skipped. false otherwise.
  */
 function skipUser(username) {
-	const skippedUsers = ["github-actions"];
+	const skippedUsers = ["github-actions", "dependabot[bot]"];
 
 	if (
 		-1 === skippedUsers.indexOf(username) &&

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -230,7 +230,7 @@ export async function getContributorsList() {
  * @return {boolean} true if the username should be skipped. false otherwise.
  */
 function skipUser(username) {
-	const skippedUsers = ["github-actions"];
+	const skippedUsers = ["github-actions", "dependabot[bot]"];
 
 	if (
 		-1 === skippedUsers.indexOf(username) &&


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
Adds the `dependabot[bot]` login to the list of ignored users.

Fixes #51.

## Why?
Dependabot does not need to be noted in the new props format since credit is not given to bot accounts on w.org.

A `Co-authored-by` trailer will be included automatically for them by GitHub for tracking in the repository's history.
