### PR TITLE
Allow a prop format to be specified

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -26,3 +26,6 @@ jobs:
 
     - name: Run the Action
       uses: ./
+      with:
+        format:
+          - 'all'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Run the Action
       uses: ./
       with:
-        format: 'svn,git'
+        format: 'svn'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Run the Action
       uses: ./
       with:
-        format: 'all'
+        format: 'svn,git'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -27,5 +27,4 @@ jobs:
     - name: Run the Action
       uses: ./
       with:
-        format:
-          - 'all'
+        format: 'all'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Run the Action
       uses: ./
       with:
-        format: 'svn'
+        format: 'all'

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ For a full breakdown of the WordPress project's Props best practices, please con
 ## Configuration
 
 ### Required configurations
-| Key      | Default         | Description                                                                         |
-|----------|-----------------|-------------------------------------------------------------------------------------|
-| `token`  | `$GITHUB_TOKEN` | GitHub token with permission to comment on the pull request.                        |
-| `format` | `git`           | The style of contributor lists to include. Valid values are `svn`, `git`, or `all`. |
+| Key      | Default         | Description                                                                                                                             |
+|----------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `token`  | `$GITHUB_TOKEN` | GitHub token with permission to comment on the pull request.                                                                            |
+| `format` | `git`           | The style of contributor lists to include. Accepted values are `svn`, `git`, or `all`, or any combination of those separated by commas. |
 
 ## Example Workflow File
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ For a full breakdown of the WordPress project's Props best practices, please con
 ## Configuration
 
 ### Required configurations
-| Key | Default         | Description                                                  |
-| --- |-----------------|--------------------------------------------------------------|
-| `token` | `$GITHUB_TOKEN` | GitHub token with permission to comment on the pull request. |
+| Key      | Default         | Description                                                                         |
+|----------|-----------------|-------------------------------------------------------------------------------------|
+| `token`  | `$GITHUB_TOKEN` | GitHub token with permission to comment on the pull request.                        |
+| `format` | `git`           | The style of contributor lists to include. Valid values are `svn`, `git`, or `all`. |
 
 ## Example Workflow File
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -35290,16 +35290,15 @@ class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		const formats = core.getMultilineInput("format") || ["git"];
+		const formats = core.getInput("format") || ["git"];
 
 		if ( formats.includes('all') ) {
 			this.format = ["git", "svn"];
-		} else {
+		} else if ( formats.includes('svn') || formats.incldues('git') ) {
 			this.format = formats;
+		} else {
+			core.error( 'A valid props format was not provided.' );
 		}
-
-		core.debug('Formats requested:');
-		core.debug(this.format);
 	}
 
 	/**
@@ -35418,6 +35417,9 @@ class GitHub {
 
 		core.debug( "Contributor list received:" );
 		core.debug( contributorsList );
+
+		core.debug('Formats requested:');
+		core.debug(this.format);
 
 		let prNumber = context.payload?.pull_request?.number;
 		if ( 'issue_comment' === context.eventName ) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -35297,6 +35297,9 @@ class GitHub {
 		} else {
 			this.format = formats;
 		}
+
+		core.debug('Formats requested:');
+		core.debug(this.format);
 	}
 
 	/**

--- a/dist/index.js
+++ b/dist/index.js
@@ -35290,7 +35290,7 @@ class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		this.format = core.getInput("format") || "both";
+		this.format = core.getInput("format") || "svn";
 	}
 
 	/**

--- a/dist/index.js
+++ b/dist/index.js
@@ -35420,8 +35420,8 @@ class GitHub {
 		core.debug( "Contributor list received:" );
 		core.debug( contributorsList );
 
-		core.debug('Formats requested:');
-		core.debug(this.format);
+		core.debug( 'Formats requested:' );
+		core.debug( this.format );
 
 		let prNumber = context.payload?.pull_request?.number;
 		if ( 'issue_comment' === context.eventName ) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -35290,7 +35290,9 @@ class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		const formats = core.getInput("format") || ["git"];
+		const formats = core.getInput("format").split(',').map(function(value){
+			return value.trim();
+		}) || "git";
 
 		if ( formats.includes('all') ) {
 			this.format = ["git", "svn"];

--- a/dist/index.js
+++ b/dist/index.js
@@ -35294,7 +35294,7 @@ class GitHub {
 
 		if ( formats.includes('all') ) {
 			this.format = ["git", "svn"];
-		} else if ( formats.includes('svn') || formats.incldues('git') ) {
+		} else if ( formats.includes('svn') || formats.includes('git') ) {
 			this.format = formats;
 		} else {
 			core.error( 'A valid props format was not provided.' );

--- a/dist/index.js
+++ b/dist/index.js
@@ -35441,8 +35441,8 @@ class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format.includes('svn') >= 0 ) {
-			if ( this.format.includes('git') >= 0 ) {
+		if ( this.format.includes('svn') ) {
+			if ( this.format.includes('git') ) {
 				commentMessage += "## Core SVN\n\n";
 			}
 
@@ -35452,8 +35452,8 @@ class GitHub {
 				"\n```\n\n";
 		}
 
-		if ( this.format.includes('git') >= 0 ) {
-			if ( this.format.includes('svn') >= 0 ) {
+		if ( this.format.includes('git') ) {
+			if ( this.format.includes('svn') ) {
 				commentMessage += "## GitHub Merge commits\n\n";
 			}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -35290,7 +35290,7 @@ class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		this.format = core.getInput("format") || "github";
+		this.format = core.getInput("format") || "both";
 	}
 
 	/**

--- a/dist/index.js
+++ b/dist/index.js
@@ -35430,8 +35430,8 @@ class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format.includes('svn') || this.format.includes('all') ) {
-			if ( this.format.includes('git') || this.format.includes('all') ) {
+		if ( this.format.indexOf('svn') >= 0 || this.format.indexOf('all') >= 0 ) {
+			if ( this.format.indexOf('git') >= 0 || this.format.indexOf('all') >= 0 ) {
 				commentMessage += "## Core SVN\n\n";
 			}
 
@@ -35441,8 +35441,8 @@ class GitHub {
 				"\n```\n\n";
 		}
 
-		if ( this.format.includes('git') || this.format.includes('all') ) {
-			if ( this.format.includes('svn') || this.format.includes('all') ) {
+		if ( this.format.indexOf('git') >= 0 || this.format.indexOf('all') >= 0 ) {
+			if ( this.format.indexOf('svn') >= 0 || this.format.indexOf('all') >= 0 ) {
 				commentMessage += "## GitHub Merge commits\n\n";
 			}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -35290,7 +35290,7 @@ class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		const formats = core.getInput("format").split(',').map(function(value){
+		const formats = core.getInput("format").replace(/ /g, '').split(',').map(function(value){
 			return value.trim();
 		}) || "git";
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -35289,6 +35289,8 @@ class GitHub {
 	constructor() {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
+
+		const format = core.getInput("format") || "github";
 	}
 
 	/**
@@ -35428,22 +35430,28 @@ class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		commentMessage += "## Core SVN\n\n" +
-		"Core Committers: Use this line as a base for the props when committing in SVN:\n" +
-		"```\n" +
-		"Props " + contributorsList['svn'].join(', ') + "." +
-		"\n```\n\n" +
-		"## GitHub Merge commits\n\n" +
-		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
-		"```\n";
-
-		if ( contributorsList['unlinked'].length > 0 ) {
-			commentMessage += "Unlinked contributors: " + contributorsList['unlinked'].join(', ') + ".\n\n";
+		if ( this.format == 'svn' || this.format == 'both' ) {
+			commentMessage += "## Core SVN\n\n" +
+				"If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
+				"```\n" +
+				"Props: " + contributorsList['svn'].join(', ') + "." +
+				"\n```\n\n";
 		}
 
-		commentMessage += contributorsList['coAuthored'].join("\n") +
-		"\n```\n\n" +
-		"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
+		if ( this.format == 'github' || this.format == 'both' ) {
+			commentMessage += "## GitHub Merge commits\n\n" +
+				"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
+				"```\n";
+
+			if (contributorsList['unlinked'].length > 0) {
+				commentMessage += "Unlinked contributors: " + contributorsList['unlinked'].join(', ') + ".\n\n";
+			}
+
+			commentMessage += contributorsList['coAuthored'].join("\n") +
+				"\n```\n\n";
+		}
+
+		commentMessage += "**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
 
 		const comment = {
 			...commentInfo,

--- a/dist/index.js
+++ b/dist/index.js
@@ -35290,7 +35290,13 @@ class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		this.format = core.getMultilineInput("format") || ["all"];
+		const formats = core.getMultilineInput("format") || ["git"];
+
+		if ( formats.includes('all') ) {
+			this.format = ["git", "svn"];
+		} else {
+			this.format = formats;
+		}
 	}
 
 	/**
@@ -35430,19 +35436,19 @@ class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format.indexOf('svn') >= 0 || this.format.indexOf('all') >= 0 ) {
-			if ( this.format.indexOf('git') >= 0 || this.format.indexOf('all') >= 0 ) {
+		if ( this.format.includes('svn') >= 0 ) {
+			if ( this.format.includes('git') >= 0 ) {
 				commentMessage += "## Core SVN\n\n";
 			}
 
-			commentMessage += "If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
+			commentMessage += "Core Committers: Use this line as a base for the props when committing in SVN:\n" +
 				"```\n" +
-				"Props: " + contributorsList['svn'].join(', ') + "." +
+				"Props " + contributorsList['svn'].join(', ') + "." +
 				"\n```\n\n";
 		}
 
-		if ( this.format.indexOf('git') >= 0 || this.format.indexOf('all') >= 0 ) {
-			if ( this.format.indexOf('svn') >= 0 || this.format.indexOf('all') >= 0 ) {
+		if ( this.format.includes('git') >= 0 ) {
+			if ( this.format.includes('svn') >= 0 ) {
 				commentMessage += "## GitHub Merge commits\n\n";
 			}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -35292,7 +35292,7 @@ class GitHub {
 
 		const formats = core.getInput("format").replace(/ /g, '').split(',').map(function(value){
 			return value.trim();
-		}) || "git";
+		}) || ["git"];
 
 		if ( formats.includes('all') ) {
 			this.format = ["git", "svn"];

--- a/dist/index.js
+++ b/dist/index.js
@@ -35290,7 +35290,7 @@ class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		const format = core.getInput("format") || "github";
+		this.format = core.getInput("format") || "github";
 	}
 
 	/**

--- a/dist/index.js
+++ b/dist/index.js
@@ -35290,7 +35290,7 @@ class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		this.format = core.getInput("format") || "svn";
+		this.format = core.getMultilineInput("format") || ["all"];
 	}
 
 	/**
@@ -35430,17 +35430,23 @@ class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format == 'svn' || this.format == 'both' ) {
-			commentMessage += "## Core SVN\n\n" +
-				"If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
+		if ( this.format.includes('svn') || this.format.includes('all') ) {
+			if ( this.format.includes('git') || this.format.includes('all') ) {
+				commentMessage += "## Core SVN\n\n";
+			}
+
+			commentMessage += "If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
 				"```\n" +
 				"Props: " + contributorsList['svn'].join(', ') + "." +
 				"\n```\n\n";
 		}
 
-		if ( this.format == 'github' || this.format == 'both' ) {
-			commentMessage += "## GitHub Merge commits\n\n" +
-				"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
+		if ( this.format.includes('git') || this.format.includes('all') ) {
+			if ( this.format.includes('svn') || this.format.includes('all') ) {
+				commentMessage += "## GitHub Merge commits\n\n";
+			}
+
+			commentMessage += "If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
 				"```\n";
 
 			if (contributorsList['unlinked'].length > 0) {

--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -77,10 +77,7 @@ jobs:
 #          # Allows a custom token to be passed.
 #          token: ${{ secrets.CUSTOM_PROPS_BOT_TOKEN }}
 #          # Uncomment to specify the prop format to display. Default is `git`.
-#          format:
-#            - 'git'
-#            - 'svn'
-#            - 'all'
+#          format: 'all'
 
       - name: Remove the props-bot label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -76,7 +76,7 @@ jobs:
 #        with:
 #          # Allows a custom token to be passed.
 #          token: ${{ secrets.CUSTOM_PROPS_BOT_TOKEN }}
-#          # Uncomment to specify the prop format to display Default is `git`.
+#          # Uncomment to specify the prop format to display. Default is `git`.
 #          format:
 #            - 'git'
 #            - 'svn'

--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -72,6 +72,15 @@ jobs:
     steps:
       - name: Gather a list of contributors
         uses: WordPress/props-bot-action@trunk
+        # Optional arguments.
+#        with:
+#          # Allows a custom token to be passed.
+#          token: ${{ secrets.CUSTOM_PROPS_BOT_TOKEN }}
+#          # Uncomment to specify the prop format to display Default is `git`.
+#          format:
+#            - 'git'
+#            - 'svn'
+#            - 'all'
 
       - name: Remove the props-bot label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -76,7 +76,7 @@ jobs:
 #        with:
 #          # Allows a custom token to be passed.
 #          token: ${{ secrets.CUSTOM_PROPS_BOT_TOKEN }}
-#          # Uncomment to specify the prop format to display. Default is `git`.
+#          # Specify the prop format to display. Default is `git`. Values should be comma separated.
 #          format: 'all'
 
       - name: Remove the props-bot label

--- a/src/github.js
+++ b/src/github.js
@@ -6,7 +6,7 @@ export default class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		this.format = core.getInput("format") || "svn";
+		this.format = core.getMultilineInput("format") || ["all"];
 	}
 
 	/**
@@ -146,17 +146,23 @@ export default class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format == 'svn' || this.format == 'both' ) {
-			commentMessage += "## Core SVN\n\n" +
-				"If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
+		if ( this.format.includes('svn') || this.format.includes('all') ) {
+			if ( this.format.includes('git') || this.format.includes('all') ) {
+				commentMessage += "## Core SVN\n\n";
+			}
+
+			commentMessage += "If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
 				"```\n" +
 				"Props: " + contributorsList['svn'].join(', ') + "." +
 				"\n```\n\n";
 		}
 
-		if ( this.format == 'github' || this.format == 'both' ) {
-			commentMessage += "## GitHub Merge commits\n\n" +
-				"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
+		if ( this.format.includes('git') || this.format.includes('all') ) {
+			if ( this.format.includes('svn') || this.format.includes('all') ) {
+				commentMessage += "## GitHub Merge commits\n\n";
+			}
+
+			commentMessage += "If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
 				"```\n";
 
 			if (contributorsList['unlinked'].length > 0) {

--- a/src/github.js
+++ b/src/github.js
@@ -10,7 +10,7 @@ export default class GitHub {
 
 		if ( formats.includes('all') ) {
 			this.format = ["git", "svn"];
-		} else if ( formats.includes('svn') || formats.incldues('git') ) {
+		} else if ( formats.includes('svn') || formats.includes('git') ) {
 			this.format = formats;
 		} else {
 			core.error( 'A valid props format was not provided.' );

--- a/src/github.js
+++ b/src/github.js
@@ -6,7 +6,9 @@ export default class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		const formats = core.getInput("format") || ["git"];
+		const formats = core.getInput("format").split(',').map(function(value){
+			return value.trim();
+		}) || "git";
 
 		if ( formats.includes('all') ) {
 			this.format = ["git", "svn"];

--- a/src/github.js
+++ b/src/github.js
@@ -137,7 +137,7 @@ export default class GitHub {
 		core.debug( contributorsList );
 
 		core.debug( 'Formats requested:' );
-		core.debug(this.format);
+		core.debug( this.format );
 
 		let prNumber = context.payload?.pull_request?.number;
 		if ( 'issue_comment' === context.eventName ) {

--- a/src/github.js
+++ b/src/github.js
@@ -6,7 +6,7 @@ export default class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		this.format = core.getInput("format") || "github";
+		this.format = core.getInput("format") || "both";
 	}
 
 	/**

--- a/src/github.js
+++ b/src/github.js
@@ -146,8 +146,8 @@ export default class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format.includes('svn') || this.format.includes('all') ) {
-			if ( this.format.includes('git') || this.format.includes('all') ) {
+		if ( this.format.indexOf('svn') >= 0 || this.format.indexOf('all') >= 0 ) {
+			if ( this.format.indexOf('git') >= 0 || this.format.indexOf('all') >= 0 ) {
 				commentMessage += "## Core SVN\n\n";
 			}
 
@@ -157,8 +157,8 @@ export default class GitHub {
 				"\n```\n\n";
 		}
 
-		if ( this.format.includes('git') || this.format.includes('all') ) {
-			if ( this.format.includes('svn') || this.format.includes('all') ) {
+		if ( this.format.indexOf('git') >= 0 || this.format.indexOf('all') >= 0 ) {
+			if ( this.format.indexOf('svn') >= 0 || this.format.indexOf('all') >= 0 ) {
 				commentMessage += "## GitHub Merge commits\n\n";
 			}
 

--- a/src/github.js
+++ b/src/github.js
@@ -6,7 +6,7 @@ export default class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		const formats = core.getInput("format").split(',').map(function(value){
+		const formats = core.getInput("format").replace(/ /g, '').split(',').map(function(value){
 			return value.trim();
 		}) || "git";
 

--- a/src/github.js
+++ b/src/github.js
@@ -6,7 +6,7 @@ export default class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		this.format = core.getInput("format") || "both";
+		this.format = core.getInput("format") || "svn";
 	}
 
 	/**

--- a/src/github.js
+++ b/src/github.js
@@ -8,7 +8,7 @@ export default class GitHub {
 
 		const formats = core.getInput("format").replace(/ /g, '').split(',').map(function(value){
 			return value.trim();
-		}) || "git";
+		}) || ["git"];
 
 		if ( formats.includes('all') ) {
 			this.format = ["git", "svn"];

--- a/src/github.js
+++ b/src/github.js
@@ -6,7 +6,13 @@ export default class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		this.format = core.getMultilineInput("format") || ["all"];
+		const formats = core.getMultilineInput("format") || ["git"];
+
+		if ( formats.includes('all') ) {
+			this.format = ["git", "svn"];
+		} else {
+			this.format = formats;
+		}
 	}
 
 	/**
@@ -146,19 +152,19 @@ export default class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format.indexOf('svn') >= 0 || this.format.indexOf('all') >= 0 ) {
-			if ( this.format.indexOf('git') >= 0 || this.format.indexOf('all') >= 0 ) {
+		if ( this.format.includes('svn') >= 0 ) {
+			if ( this.format.includes('git') >= 0 ) {
 				commentMessage += "## Core SVN\n\n";
 			}
 
-			commentMessage += "If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
+			commentMessage += "Core Committers: Use this line as a base for the props when committing in SVN:\n" +
 				"```\n" +
-				"Props: " + contributorsList['svn'].join(', ') + "." +
+				"Props " + contributorsList['svn'].join(', ') + "." +
 				"\n```\n\n";
 		}
 
-		if ( this.format.indexOf('git') >= 0 || this.format.indexOf('all') >= 0 ) {
-			if ( this.format.indexOf('svn') >= 0 || this.format.indexOf('all') >= 0 ) {
+		if ( this.format.includes('git') >= 0 ) {
+			if ( this.format.includes('svn') >= 0 ) {
 				commentMessage += "## GitHub Merge commits\n\n";
 			}
 

--- a/src/github.js
+++ b/src/github.js
@@ -157,8 +157,8 @@ export default class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format.includes('svn') >= 0 ) {
-			if ( this.format.includes('git') >= 0 ) {
+		if ( this.format.includes('svn') ) {
+			if ( this.format.includes('git') ) {
 				commentMessage += "## Core SVN\n\n";
 			}
 
@@ -168,8 +168,8 @@ export default class GitHub {
 				"\n```\n\n";
 		}
 
-		if ( this.format.includes('git') >= 0 ) {
-			if ( this.format.includes('svn') >= 0 ) {
+		if ( this.format.includes('git') ) {
+			if ( this.format.includes('svn') ) {
 				commentMessage += "## GitHub Merge commits\n\n";
 			}
 

--- a/src/github.js
+++ b/src/github.js
@@ -6,7 +6,7 @@ export default class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		const format = core.getInput("format") || "github";
+		this.format = core.getInput("format") || "github";
 	}
 
 	/**

--- a/src/github.js
+++ b/src/github.js
@@ -6,16 +6,15 @@ export default class GitHub {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
 
-		const formats = core.getMultilineInput("format") || ["git"];
+		const formats = core.getInput("format") || ["git"];
 
 		if ( formats.includes('all') ) {
 			this.format = ["git", "svn"];
-		} else {
+		} else if ( formats.includes('svn') || formats.incldues('git') ) {
 			this.format = formats;
+		} else {
+			core.error( 'A valid props format was not provided.' );
 		}
-
-		core.debug('Formats requested:');
-		core.debug(this.format);
 	}
 
 	/**
@@ -134,6 +133,9 @@ export default class GitHub {
 
 		core.debug( "Contributor list received:" );
 		core.debug( contributorsList );
+
+		core.debug('Formats requested:');
+		core.debug(this.format);
 
 		let prNumber = context.payload?.pull_request?.number;
 		if ( 'issue_comment' === context.eventName ) {

--- a/src/github.js
+++ b/src/github.js
@@ -5,6 +5,8 @@ export default class GitHub {
 	constructor() {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
+
+		const format = core.getInput("format") || "github";
 	}
 
 	/**
@@ -144,22 +146,28 @@ export default class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		commentMessage += "## Core SVN\n\n" +
-		"Core Committers: Use this line as a base for the props when committing in SVN:\n" +
-		"```\n" +
-		"Props " + contributorsList['svn'].join(', ') + "." +
-		"\n```\n\n" +
-		"## GitHub Merge commits\n\n" +
-		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
-		"```\n";
-
-		if ( contributorsList['unlinked'].length > 0 ) {
-			commentMessage += "Unlinked contributors: " + contributorsList['unlinked'].join(', ') + ".\n\n";
+		if ( this.format == 'svn' || this.format == 'both' ) {
+			commentMessage += "## Core SVN\n\n" +
+				"If you're a Core Committer, use this list when committing to `wordpress-develop` in SVN:\n" +
+				"```\n" +
+				"Props: " + contributorsList['svn'].join(', ') + "." +
+				"\n```\n\n";
 		}
 
-		commentMessage += contributorsList['coAuthored'].join("\n") +
-		"\n```\n\n" +
-		"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
+		if ( this.format == 'github' || this.format == 'both' ) {
+			commentMessage += "## GitHub Merge commits\n\n" +
+				"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
+				"```\n";
+
+			if (contributorsList['unlinked'].length > 0) {
+				commentMessage += "Unlinked contributors: " + contributorsList['unlinked'].join(', ') + ".\n\n";
+			}
+
+			commentMessage += contributorsList['coAuthored'].join("\n") +
+				"\n```\n\n";
+		}
+
+		commentMessage += "**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
 
 		const comment = {
 			...commentInfo,

--- a/src/github.js
+++ b/src/github.js
@@ -13,6 +13,9 @@ export default class GitHub {
 		} else {
 			this.format = formats;
 		}
+
+		core.debug('Formats requested:');
+		core.debug(this.format);
 	}
 
 	/**

--- a/src/github.js
+++ b/src/github.js
@@ -136,7 +136,7 @@ export default class GitHub {
 		core.debug( "Contributor list received:" );
 		core.debug( contributorsList );
 
-		core.debug('Formats requested:');
+		core.debug( 'Formats requested:' );
 		core.debug(this.format);
 
 		let prNumber = context.payload?.pull_request?.number;


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
This updates the action to allow a repository to configure the specific formats they want included in the bot's comments.

## Why?
Often times, only one format is relavent to a given repo.  This also helps make the comment shorter. Including both formats makes it quite long.

## How?
Using the `formats` input, `all`, `git`, or `svn` can now be specified. The default is `git`.

Fixes #38, #47.