### PR TITLE
Revert "Allow a prop format to be specified"

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -26,5 +26,3 @@ jobs:
 
     - name: Run the Action
       uses: ./
-      with:
-        format: 'all'

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ For a full breakdown of the WordPress project's Props best practices, please con
 ## Configuration
 
 ### Required configurations
-| Key      | Default         | Description                                                                                                                             |
-|----------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `token`  | `$GITHUB_TOKEN` | GitHub token with permission to comment on the pull request.                                                                            |
-| `format` | `git`           | The style of contributor lists to include. Accepted values are `svn`, `git`, or `all`, or any combination of those separated by commas. |
+| Key | Default         | Description                                                  |
+| --- |-----------------|--------------------------------------------------------------|
+| `token` | `$GITHUB_TOKEN` | GitHub token with permission to comment on the pull request. |
 
 ## Example Workflow File
 

--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -72,12 +72,6 @@ jobs:
     steps:
       - name: Gather a list of contributors
         uses: WordPress/props-bot-action@trunk
-        # Optional arguments.
-#        with:
-#          # Allows a custom token to be passed.
-#          token: ${{ secrets.CUSTOM_PROPS_BOT_TOKEN }}
-#          # Specify the prop format to display. Default is `git`. Values should be comma separated.
-#          format: 'all'
 
       - name: Remove the props-bot label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/src/github.js
+++ b/src/github.js
@@ -5,18 +5,6 @@ export default class GitHub {
 	constructor() {
 		const token = core.getInput("token") || process.env.GITHUB_TOKEN || "";
 		this.octokit = github.getOctokit(token);
-
-		const formats = core.getInput("format").replace(/ /g, '').split(',').map(function(value){
-			return value.trim();
-		}) || ["git"];
-
-		if ( formats.includes('all') ) {
-			this.format = ["git", "svn"];
-		} else if ( formats.includes('svn') || formats.includes('git') ) {
-			this.format = formats;
-		} else {
-			core.error( 'A valid props format was not provided.' );
-		}
 	}
 
 	/**
@@ -136,9 +124,6 @@ export default class GitHub {
 		core.debug( "Contributor list received:" );
 		core.debug( contributorsList );
 
-		core.debug( 'Formats requested:' );
-		core.debug( this.format );
-
 		let prNumber = context.payload?.pull_request?.number;
 		if ( 'issue_comment' === context.eventName ) {
 			prNumber = context.payload?.issue?.number;
@@ -159,34 +144,22 @@ export default class GitHub {
 				"Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n";
 		}
 
-		if ( this.format.includes('svn') ) {
-			if ( this.format.includes('git') ) {
-				commentMessage += "## Core SVN\n\n";
-			}
+		commentMessage += "## Core SVN\n\n" +
+		"Core Committers: Use this line as a base for the props when committing in SVN:\n" +
+		"```\n" +
+		"Props " + contributorsList['svn'].join(', ') + "." +
+		"\n```\n\n" +
+		"## GitHub Merge commits\n\n" +
+		"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
+		"```\n";
 
-			commentMessage += "Core Committers: Use this line as a base for the props when committing in SVN:\n" +
-				"```\n" +
-				"Props " + contributorsList['svn'].join(', ') + "." +
-				"\n```\n\n";
+		if ( contributorsList['unlinked'].length > 0 ) {
+			commentMessage += "Unlinked contributors: " + contributorsList['unlinked'].join(', ') + ".\n\n";
 		}
 
-		if ( this.format.includes('git') ) {
-			if ( this.format.includes('svn') ) {
-				commentMessage += "## GitHub Merge commits\n\n";
-			}
-
-			commentMessage += "If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
-				"```\n";
-
-			if (contributorsList['unlinked'].length > 0) {
-				commentMessage += "Unlinked contributors: " + contributorsList['unlinked'].join(', ') + ".\n\n";
-			}
-
-			commentMessage += contributorsList['coAuthored'].join("\n") +
-				"\n```\n\n";
-		}
-
-		commentMessage += "**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
+		commentMessage += contributorsList['coAuthored'].join("\n") +
+		"\n```\n\n" +
+		"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
 
 		const comment = {
 			...commentInfo,


### PR DESCRIPTION
Reverts WordPress/props-bot-action#61

This is causing failures, reverting so it can be further investigated. See: https://github.com/WordPress/gutenberg/actions/runs/7806504966/job/21293004833?pr=58107