### PR TITLE
Avoid posting an empty props list

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint 
+name: Lint
 
 on:
     pull_request:
@@ -16,7 +16,7 @@ jobs:
     # - Installs npm dependencies.
     # - Runs the linters.
     lint:
-        name: Run Linters 
+        name: Run Linters
         runs-on: ubuntu-latest
 
         steps:
@@ -32,5 +32,5 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
-            - name: Run linters 
+            - name: Run linters
               run: npm run lint

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,7 +17,7 @@ jobs:
     # - Checks out the repository.
     # - Runs the Action.
     test:
-        name: Test the Action
+        name: Run Props Bot
         runs-on: ubuntu-latest
 
         steps:

--- a/dist/index.js
+++ b/dist/index.js
@@ -35461,7 +35461,7 @@ class GitHub {
 				'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n';
 		}
 
-		if ( this.format.includes( 'svn' ) ) {
+		if ( this.format.includes( 'svn' ) && contributorsList.svn.length > 0 ) {
 			if ( this.format.includes( 'git' ) ) {
 				commentMessage += '## Core SVN\n\n';
 			}
@@ -35491,8 +35491,12 @@ class GitHub {
 					'.\n\n';
 			}
 
-			commentMessage +=
-				contributorsList.coAuthored.join( '\n' ) + '\n```\n\n';
+			if ( contributorsList.git.length > 0 ) {
+				commentMessage +=
+					contributorsList.coAuthored.join('\n');
+			}
+
+			commentMessage += '\n```\n\n';
 		}
 
 		commentMessage +=

--- a/dist/index.js
+++ b/dist/index.js
@@ -35461,7 +35461,10 @@ class GitHub {
 				'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n';
 		}
 
-		if ( this.format.includes( 'svn' ) && contributorsList.svn.length > 0 ) {
+		if (
+			this.format.includes( 'svn' ) &&
+			contributorsList.svn.length > 0
+		) {
 			if ( this.format.includes( 'git' ) ) {
 				commentMessage += '## Core SVN\n\n';
 			}
@@ -35492,8 +35495,7 @@ class GitHub {
 			}
 
 			if ( contributorsList.coAuthored.length > 0 ) {
-				commentMessage +=
-					contributorsList.coAuthored.join('\n');
+				commentMessage += contributorsList.coAuthored.join( '\n' );
 			}
 
 			commentMessage += '\n```\n\n';

--- a/dist/index.js
+++ b/dist/index.js
@@ -35491,7 +35491,7 @@ class GitHub {
 					'.\n\n';
 			}
 
-			if ( contributorsList.git.length > 0 ) {
+			if ( contributorsList.coAuthored.length > 0 ) {
 				commentMessage +=
 					contributorsList.coAuthored.join('\n');
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10314,12 +10314,6 @@
 			"deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
 			"dev": true
 		},
-		"node_modules/ip": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-			"integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
-			"dev": true
-		},
 		"node_modules/ip-address": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -13794,13 +13788,12 @@
 			}
 		},
 		"node_modules/pac-resolver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-			"integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
 			"dev": true,
 			"dependencies": {
 				"degenerator": "^5.0.0",
-				"ip": "^1.1.8",
 				"netmask": "^2.0.2"
 			},
 			"engines": {
@@ -26257,12 +26250,6 @@
 			"integrity": "sha512-IMSCKVf0USrM/959vj3xac7s8f87sc+80Y/ipBzdKy4ifBv5Gsj2tZ41EAaURVg01QU71fYr77uA8Meh6kELbg==",
 			"dev": true
 		},
-		"ip": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-			"integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
-			"dev": true
-		},
 		"ip-address": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -28863,13 +28850,12 @@
 			}
 		},
 		"pac-resolver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-			"integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
 			"dev": true,
 			"requires": {
 				"degenerator": "^5.0.0",
-				"ip": "^1.1.8",
 				"netmask": "^2.0.2"
 			}
 		},

--- a/src/github.js
+++ b/src/github.js
@@ -208,7 +208,7 @@ export default class GitHub {
 					'.\n\n';
 			}
 
-			if ( contributorsList.git.length > 0 ) {
+			if ( contributorsList.coAuthored.length > 0 ) {
 				commentMessage +=
 					contributorsList.coAuthored.join('\n');
 			}

--- a/src/github.js
+++ b/src/github.js
@@ -178,7 +178,7 @@ export default class GitHub {
 				'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n';
 		}
 
-		if ( this.format.includes( 'svn' ) ) {
+		if ( this.format.includes( 'svn' ) && contributorsList.svn.length > 0 ) {
 			if ( this.format.includes( 'git' ) ) {
 				commentMessage += '## Core SVN\n\n';
 			}
@@ -208,8 +208,12 @@ export default class GitHub {
 					'.\n\n';
 			}
 
-			commentMessage +=
-				contributorsList.coAuthored.join( '\n' ) + '\n```\n\n';
+			if ( contributorsList.git.length > 0 ) {
+				commentMessage +=
+					contributorsList.coAuthored.join('\n');
+			}
+
+			commentMessage += '\n```\n\n';
 		}
 
 		commentMessage +=

--- a/src/github.js
+++ b/src/github.js
@@ -178,7 +178,10 @@ export default class GitHub {
 				'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n';
 		}
 
-		if ( this.format.includes( 'svn' ) && contributorsList.svn.length > 0 ) {
+		if (
+			this.format.includes( 'svn' ) &&
+			contributorsList.svn.length > 0
+		) {
 			if ( this.format.includes( 'git' ) ) {
 				commentMessage += '## Core SVN\n\n';
 			}
@@ -209,8 +212,7 @@ export default class GitHub {
 			}
 
 			if ( contributorsList.coAuthored.length > 0 ) {
-				commentMessage +=
-					contributorsList.coAuthored.join('\n');
+				commentMessage += contributorsList.coAuthored.join( '\n' );
 			}
 
 			commentMessage += '\n```\n\n';


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
This PR makes the necessary adjustments to avoid posting an empty list of contributors when the only contributors that exist are unlinked.

## Why?
Showing empty lists is unnecessary.

Fixes #69.
