### PR TITLE
Change the bug report link details

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -47,7 +47,7 @@ body:
       attributes:
           label: Link
           description: |
-              Please include a link to a GitHub pull request run showing the issue.
-          placeholder: https://github.com/WordPress/wordpress-develop/pull/5990
+              Please include a link to a GitHub Action workflow run demonstrating the issue.
+          placeholder: https://github.com/WordPress/props-bot-action/actions/runs/7923792615/attempts/1
       validations:
           required: false


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
When someone is reporting a bug, an Actions workflow run link is more useful than a PR link. Previously it said "Pull Request run", which was confusing because PRs don't run. Actions do.