### PR TITLE
Example workflow: Don't run the bot when PR is from a fork

### DIFF
--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -57,7 +57,7 @@ jobs:
         # The job will run when pull requests are open, ready for review and:
         #
         # - A comment is added to the pull request.
-        # - A review is created or commented on (unless PR comes from a fork).
+        # - A review is created or commented on (unless PR originates from a fork).
         # - The pull request is opened, synchronized, marked ready for review, or reopened.
         # - The `props-bot` label is added to the pull request.
         if: |

--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -57,13 +57,13 @@ jobs:
         # The job will run when pull requests are open, ready for review and:
         #
         # - A comment is added to the pull request.
-        # - A review is created or commented on.
+        # - A review is created or commented on (unless PR comes from a fork).
         # - The pull request is opened, synchronized, marked ready for review, or reopened.
         # - The `props-bot` label is added to the pull request.
         if: |
             (
               github.event_name == 'issue_comment' && github.event.issue.pull_request ||
-              contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
+              ( contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && ! github.event.pull_request.head.repo.fork ) ||
               github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
               'props-bot' == github.event.label.name
             ) &&


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?

This updates the example workflow file to prevent `pull_request_review` and `pull_request_review_comment` events from attempting to run the bot.

## Why?
For PRs that originate from forked repositories, `pull_request_review` and `pull_request_review_comment` events do not have the permissions necessary to comment on the PR.

See #57.