### PR TITLE
Add `github-advanced-security` to the exclude list.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37977,7 +37977,7 @@ async function getContributorsList() {
  * @return {boolean} true if the username should be skipped. false otherwise.
  */
 function skipUser( username ) {
-	const skippedUsers = [ 'github-actions', 'dependabot[bot]' ];
+	const skippedUsers = [ 'github-actions', 'dependabot[bot]', 'github-advanced-security' ];
 
 	if (
 		-1 === skippedUsers.indexOf( username ) &&

--- a/dist/index.js
+++ b/dist/index.js
@@ -37977,7 +37977,11 @@ async function getContributorsList() {
  * @return {boolean} true if the username should be skipped. false otherwise.
  */
 function skipUser( username ) {
-	const skippedUsers = [ 'github-actions', 'dependabot[bot]', 'github-advanced-security' ];
+	const skippedUsers = [
+		'github-actions',
+		'dependabot[bot]',
+		'github-advanced-security',
+	];
 
 	if (
 		-1 === skippedUsers.indexOf( username ) &&

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -243,7 +243,11 @@ export async function getContributorsList() {
  * @return {boolean} true if the username should be skipped. false otherwise.
  */
 function skipUser( username ) {
-	const skippedUsers = [ 'github-actions', 'dependabot[bot]', 'github-advanced-security' ];
+	const skippedUsers = [
+		'github-actions',
+		'dependabot[bot]',
+		'github-advanced-security',
+	];
 
 	if (
 		-1 === skippedUsers.indexOf( username ) &&

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -243,7 +243,7 @@ export async function getContributorsList() {
  * @return {boolean} true if the username should be skipped. false otherwise.
  */
 function skipUser( username ) {
-	const skippedUsers = [ 'github-actions', 'dependabot[bot]' ];
+	const skippedUsers = [ 'github-actions', 'dependabot[bot]', 'github-advanced-security' ];
 
 	if (
 		-1 === skippedUsers.indexOf( username ) &&


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
This adds `github-advanced-security` to the exclude list.

## Why?
This is an automated bot account associated with CodeQL and will never be linked to a w.org account.

See #77.