### PR TITLE
Always create new comment for visibility

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35961,11 +35961,6 @@ class GitHub {
 		commentMessage +=
 			"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
 
-		const comment = {
-			...commentInfo,
-			body: commentMessage,
-		};
-
 		for await ( const response of this.octokit.paginate.iterator(
 			this.octokit.rest.issues.listComments,
 			commentInfo
@@ -35988,13 +35983,12 @@ class GitHub {
 		}
 
 		if ( commentId ) {
-			core.info( `Updating previous comment #${ commentId }` );
+			core.info( `Deleting previous comment #${ commentId }` );
 
 			try {
-				await this.octokit.rest.issues.updateComment( {
+				await this.octokit.rest.issues.deleteComment( {
 					...context.repo,
 					comment_id: commentId,
-					body: comment.body,
 				} );
 			} catch ( e ) {
 				core.info( 'Error editing previous comment: ' + e.message );
@@ -36002,14 +35996,14 @@ class GitHub {
 			}
 		}
 
-		// No previous or edit comment failed.
-		if ( ! commentId ) {
-			core.info( 'No previous comment found. Creating a new one.' );
-			try {
-				await this.octokit.rest.issues.createComment( comment );
-			} catch ( e ) {
-				core.error( `Error creating comment: ${ e.message }` );
-			}
+		core.info( 'Creating a new comment.' );
+		try {
+			await this.octokit.rest.issues.createComment( {
+				...commentInfo,
+				body: commentMessage,
+			} );
+		} catch ( e ) {
+			core.error( `Error creating comment: ${ e.message }` );
 		}
 	}
 }

--- a/src/github.js
+++ b/src/github.js
@@ -221,11 +221,6 @@ export default class GitHub {
 		commentMessage +=
 			"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
 
-		const comment = {
-			...commentInfo,
-			body: commentMessage,
-		};
-
 		for await ( const response of this.octokit.paginate.iterator(
 			this.octokit.rest.issues.listComments,
 			commentInfo
@@ -248,13 +243,12 @@ export default class GitHub {
 		}
 
 		if ( commentId ) {
-			core.info( `Updating previous comment #${ commentId }` );
+			core.info( `Deleting previous comment #${ commentId }` );
 
 			try {
-				await this.octokit.rest.issues.updateComment( {
+				await this.octokit.rest.issues.deleteComment( {
 					...context.repo,
 					comment_id: commentId,
-					body: comment.body,
 				} );
 			} catch ( e ) {
 				core.info( 'Error editing previous comment: ' + e.message );
@@ -262,14 +256,14 @@ export default class GitHub {
 			}
 		}
 
-		// No previous or edit comment failed.
-		if ( ! commentId ) {
-			core.info( 'No previous comment found. Creating a new one.' );
-			try {
-				await this.octokit.rest.issues.createComment( comment );
-			} catch ( e ) {
-				core.error( `Error creating comment: ${ e.message }` );
-			}
+		core.info( 'Creating a new comment.' );
+		try {
+			await this.octokit.rest.issues.createComment( {
+				...commentInfo,
+				body: commentMessage,
+			} );
+		} catch ( e ) {
+			core.error( `Error creating comment: ${ e.message }` );
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
<!-- In a few words, what is the PR doing? -->

Always create a new comment at the bottom of the PR.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here along with that information. -->

To increase visibility of the comment, and make it harder to miss.

The problem with editor the comment is that is maintains the same position on a PR.

* When the time of merging comes, it's easy to forget adding the props, because the message is not directly in front of you.
* When remembering to add them, you have to scroll back and find the comment.
* Often, on much discussed and reviewed PRs, this comment will disappear because Github hides/collapses older comments.

## How?
<!-- How does this PR addressing the issue at hand? -->

Instead of editing the previous comment, delete it. Then always add a fresh comment, which will appear at the bottom.

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

You can see a test run on https://github.com/WordPress/gutenberg/pull/62756: https://github.com/WordPress/gutenberg/actions/runs/9616861940/job/26528178346?pr=62756