### PR TITLE
Fix typo in `issue_comment` event filter.

### DIFF
--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -18,7 +18,7 @@ on:
     # You cannot filter this event for PR comments only.
     # However, the logic below does short-circuit the workflow for issues.
     issue_comment:
-        type:
+        types:
             - created
     # This event will run everytime a new PR review is initially submitted.
     pull_request_review:


### PR DESCRIPTION
## What?
This fixes a typo in the `types` keyword to ensure the bot only runs for the specified event types.

## Why?
By default, `issue_comment` [runs when a comment is](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment) `created`, `edited`, and `deleted`. Because `types` was misspelled, the bot would run unnecessarily on comment edit or delete.

Props to @jeherve for reporting, and @aaronjorbin/@Mamaduka for reviewing and merging the original report in WordPress/Gutenberg#64557.