### PR TITLE
Add codecov to skipped users

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38438,6 +38438,7 @@ function skipUser( username ) {
 		'github-actions',
 		'dependabot[bot]',
 		'github-advanced-security',
+		'codecov',
 	];
 
 	if (

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -247,6 +247,7 @@ function skipUser( username ) {
 		'github-actions',
 		'dependabot[bot]',
 		'github-advanced-security',
+		'codecov',
 	];
 
 	if (


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?

As a follow up to #79, this adds `codecov` to the list of users which are skipped from props bot. 

<!-- In a few words, what is the PR doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here along with that information. -->

In https://github.com/WordPress/performance/pull/1653 we're adding Codecov code coverage but props bot is giving an error:

> Gathering contributor list.
> Error: Request failed due to following response errors:
>  - Could not resolve to a User with the login of 'codecov'.

See https://github.com/WordPress/props-bot-action/issues/77.