### PR TITLE
Include old Dependabot name.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38437,6 +38437,7 @@ function skipUser( username ) {
 	const skippedUsers = [
 		'github-actions',
 		'dependabot[bot]',
+		'dependabot', // Here for backwards compatibility with old pull requests.
 		'github-advanced-security',
 		'codecov',
 	];

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -246,6 +246,7 @@ function skipUser( username ) {
 	const skippedUsers = [
 		'github-actions',
 		'dependabot[bot]',
+		'dependabot', // Here for backwards compatibility with old pull requests.
 		'github-advanced-security',
 		'codecov',
 	];


### PR DESCRIPTION
## What?
It seems that Dependabot used to create pull requests with `dependabot` and not `dependabot[bot]` as seen by the error in #97.

## How?
This adds `dependabot` to the skipped users list for backwards compatibility in case an old PR is revived.
