### PR TITLE
Introduce a CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+#
+# All contributions to Props Bot are welcome. However, because Props Bot can be used in both public and private
+# repositories, it's important to ensure someone familiar with the potential security risks involved with GitHub Actions
+# reviews changes to this action repository.
+#
+# For now, this is limited to members of the Props Bot Core team, but can be expanded in the future.
+#
+@WordPress/props-bot-core


### PR DESCRIPTION
## What?
This introduces a CODEOWNERS file for the repository.

## Why?
Because Props Bot can be run in both public and private repositories, it's important to ensure changes are properly reviewed before merging to ensure potential security risks are properly considered.

## How?
GitHub does not currently support configuring a rule that requires a member of a specific team to review a PR before allowing to merge, but it does support a requirement that at least one review from a listed member of the CODEOWNER file provides a review. This rule is now in effect, so this uses that file to specify the @WordPress/props-bot-core team as a requirement.