### PR TITLE
Add Copilot AI Agent to skipped users

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39381,6 +39381,7 @@ function skipUser( username ) {
 		'github-advanced-security',
 		'codecov',
 		'copilot-pull-request-reviewer',
+		'copilot-swe-agent',
 	];
 
 	if (

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -250,6 +250,7 @@ function skipUser( username ) {
 		'github-advanced-security',
 		'codecov',
 		'copilot-pull-request-reviewer',
+		'copilot-swe-agent',
 	];
 
 	if (


### PR DESCRIPTION
Similar to #185

## What?

Add Copilot AI Agent to skipped users.


## Why?

I've noticed that there are Gutenberg contributors who submit PRs using [GitHub Copilot Coding Agent](https://github.blog/jp/2025-05-20-github-copilot-meet-the-new-coding-agent/). If the agent commits, the username becomes `copilot-swe-agent`.

The GitHub Action won't fail because this is a real user, but we probably don't want to add this user as a contributor.

See https://github.com/WordPress/gutenberg/pull/70741#issuecomment-3078844345