### PR TITLE
Prevent failures when `ghost` accounts are encountered

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36954,6 +36954,12 @@ class GitHub {
 			commentMessage += '\n```\n\n';
 		}
 
+		// Note that ghosts were detected. Spooky! 👻
+		if ( contributorsList.hasGhostActivity ) {
+			commentMessage +=
+				'At least one `ghost` was discovered. `ghost`s represent deleted GitHub user accounts.\n\n';
+		}
+
 		commentMessage +=
 			"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
 
@@ -39259,8 +39265,17 @@ async function getContributorsList() {
 	core.debug( 'Raw contributor data:' );
 	core.debug( contributorData );
 
+	// Keep track of whether the Ghostbusters are needed.
+	let hasGhostActivity = false;
+
 	// Process pull request commits.
 	for ( const commit of contributorData?.commits?.nodes || [] ) {
+		// Set a trap for some ghosts.
+		if ( ! commit.commit.author ) {
+			hasGhostActivity = true;
+			continue;
+		}
+
 		/*
 		 * Commits are sometimes made by an email that is not associated with a GitHub account.
 		 * For these, info that may help us guess later.
@@ -39287,9 +39302,13 @@ async function getContributorsList() {
 
 	// Process pull request reviews.
 	contributorData.reviews.nodes
-		.filter(
-			( review ) => review.author && ! skipUser( review.author.login )
-		)
+		.filter( ( review ) => {
+			if ( ! review.author ) {
+				hasGhostActivity = true;
+				return false;
+			}
+			return ! skipUser( review.author.login );
+		} )
 		.forEach( ( review ) =>
 			contributors.reviewers.add( review.author.login )
 		);
@@ -39299,9 +39318,13 @@ async function getContributorsList() {
 
 	// Process pull request comments.
 	contributorData.comments.nodes
-		.filter(
-			( comment ) => comment.author && ! skipUser( comment.author.login )
-		)
+		.filter( ( comment ) => {
+			if ( ! comment.author ) {
+				hasGhostActivity = true;
+				return false;
+			}
+			return ! skipUser( comment.author.login );
+		} )
 		.forEach( ( comment ) =>
 			contributors.commenters.add( comment.author.login )
 		);
@@ -39311,7 +39334,10 @@ async function getContributorsList() {
 
 	// Process reporters and commenters for linked issues.
 	for ( const linkedIssue of contributorData.closingIssuesReferences.nodes ) {
-		if ( linkedIssue.author && ! skipUser( linkedIssue.author.login ) ) {
+		// Lay a proton trap for any more ghosts.
+		if ( ! linkedIssue.author ) {
+			hasGhostActivity = true;
+		} else if ( ! skipUser( linkedIssue.author.login ) ) {
 			contributors.reporters.add( linkedIssue.author.login );
 		}
 
@@ -39423,6 +39449,9 @@ async function getContributorsList() {
 			} )
 			.filter( ( el ) => el );
 	} );
+
+	// Include findings so Ghostbuster HQ can be notified.
+	contributorLists.hasGhostActivity = hasGhostActivity;
 
 	core.debug( contributorLists );
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -39287,7 +39287,9 @@ async function getContributorsList() {
 
 	// Process pull request reviews.
 	contributorData.reviews.nodes
-		.filter( ( review ) => ! skipUser( review.author.login ) )
+		.filter(
+			( review ) => review.author && ! skipUser( review.author.login )
+		)
 		.forEach( ( review ) =>
 			contributors.reviewers.add( review.author.login )
 		);
@@ -39297,7 +39299,9 @@ async function getContributorsList() {
 
 	// Process pull request comments.
 	contributorData.comments.nodes
-		.filter( ( comment ) => ! skipUser( comment.author.login ) )
+		.filter(
+			( comment ) => comment.author && ! skipUser( comment.author.login )
+		)
 		.forEach( ( comment ) =>
 			contributors.commenters.add( comment.author.login )
 		);
@@ -39307,12 +39311,15 @@ async function getContributorsList() {
 
 	// Process reporters and commenters for linked issues.
 	for ( const linkedIssue of contributorData.closingIssuesReferences.nodes ) {
-		if ( ! skipUser( linkedIssue.author.login ) ) {
+		if ( linkedIssue.author && ! skipUser( linkedIssue.author.login ) ) {
 			contributors.reporters.add( linkedIssue.author.login );
 		}
 
 		for ( const issueComment of linkedIssue.comments.nodes ) {
-			if ( skipUser( issueComment.author.login ) ) {
+			if (
+				! issueComment.author ||
+				skipUser( issueComment.author.login )
+			) {
 				continue;
 			}
 

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -72,8 +72,17 @@ export async function getContributorsList() {
 	core.debug( 'Raw contributor data:' );
 	core.debug( contributorData );
 
+	// Keep track of whether the Ghostbusters are needed.
+	let hasGhostActivity = false;
+
 	// Process pull request commits.
 	for ( const commit of contributorData?.commits?.nodes || [] ) {
+		// Set a trap for some ghosts.
+		if ( ! commit.commit.author ) {
+			hasGhostActivity = true;
+			continue;
+		}
+
 		/*
 		 * Commits are sometimes made by an email that is not associated with a GitHub account.
 		 * For these, info that may help us guess later.
@@ -100,9 +109,13 @@ export async function getContributorsList() {
 
 	// Process pull request reviews.
 	contributorData.reviews.nodes
-		.filter(
-			( review ) => review.author && ! skipUser( review.author.login )
-		)
+		.filter( ( review ) => {
+			if ( ! review.author ) {
+				hasGhostActivity = true;
+				return false;
+			}
+			return ! skipUser( review.author.login );
+		} )
 		.forEach( ( review ) =>
 			contributors.reviewers.add( review.author.login )
 		);
@@ -112,9 +125,13 @@ export async function getContributorsList() {
 
 	// Process pull request comments.
 	contributorData.comments.nodes
-		.filter(
-			( comment ) => comment.author && ! skipUser( comment.author.login )
-		)
+		.filter( ( comment ) => {
+			if ( ! comment.author ) {
+				hasGhostActivity = true;
+				return false;
+			}
+			return ! skipUser( comment.author.login );
+		} )
 		.forEach( ( comment ) =>
 			contributors.commenters.add( comment.author.login )
 		);
@@ -124,7 +141,10 @@ export async function getContributorsList() {
 
 	// Process reporters and commenters for linked issues.
 	for ( const linkedIssue of contributorData.closingIssuesReferences.nodes ) {
-		if ( linkedIssue.author && ! skipUser( linkedIssue.author.login ) ) {
+		// Lay a proton trap for any more ghosts.
+		if ( ! linkedIssue.author ) {
+			hasGhostActivity = true;
+		} else if ( ! skipUser( linkedIssue.author.login ) ) {
 			contributors.reporters.add( linkedIssue.author.login );
 		}
 
@@ -236,6 +256,9 @@ export async function getContributorsList() {
 			} )
 			.filter( ( el ) => el );
 	} );
+
+	// Include findings so Ghostbuster HQ can be notified.
+	contributorLists.hasGhostActivity = hasGhostActivity;
 
 	core.debug( contributorLists );
 

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -100,7 +100,9 @@ export async function getContributorsList() {
 
 	// Process pull request reviews.
 	contributorData.reviews.nodes
-		.filter( ( review ) => ! skipUser( review.author.login ) )
+		.filter(
+			( review ) => review.author && ! skipUser( review.author.login )
+		)
 		.forEach( ( review ) =>
 			contributors.reviewers.add( review.author.login )
 		);
@@ -110,7 +112,9 @@ export async function getContributorsList() {
 
 	// Process pull request comments.
 	contributorData.comments.nodes
-		.filter( ( comment ) => ! skipUser( comment.author.login ) )
+		.filter(
+			( comment ) => comment.author && ! skipUser( comment.author.login )
+		)
 		.forEach( ( comment ) =>
 			contributors.commenters.add( comment.author.login )
 		);
@@ -120,12 +124,15 @@ export async function getContributorsList() {
 
 	// Process reporters and commenters for linked issues.
 	for ( const linkedIssue of contributorData.closingIssuesReferences.nodes ) {
-		if ( ! skipUser( linkedIssue.author.login ) ) {
+		if ( linkedIssue.author && ! skipUser( linkedIssue.author.login ) ) {
 			contributors.reporters.add( linkedIssue.author.login );
 		}
 
 		for ( const issueComment of linkedIssue.comments.nodes ) {
-			if ( skipUser( issueComment.author.login ) ) {
+			if (
+				! issueComment.author ||
+				skipUser( issueComment.author.login )
+			) {
 				continue;
 			}
 

--- a/src/github.js
+++ b/src/github.js
@@ -218,6 +218,12 @@ export default class GitHub {
 			commentMessage += '\n```\n\n';
 		}
 
+		// Note that ghosts were detected. Spooky! 👻
+		if ( contributorsList.hasGhostActivity ) {
+			commentMessage +=
+				'At least one `ghost` was discovered. `ghost`s represent deleted GitHub user accounts.\n\n';
+		}
+
 		commentMessage +=
 			"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
 


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
This guards against scenarios where a user contributed in some way before deleting their GitHub user account.

Fixes #198.

## Why?
When user accounts are deleted from GitHub a `ghost` placeholder is used instead and `null` is returned for the `*.author` property instead of the typical user object. The bot fails in these scenarios.

## How?
<!-- How does this PR addressing the issue at hand? -->

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
