### PR TITLE
Sync the test workflow with the example.

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -45,6 +45,7 @@ jobs:
     # Compiles a list of props for a pull request.
     #
     # Performs the following steps:
+    # - Checks out the repository.
     # - Collects a list of contributor props and leaves a comment.
     # - Removes the props-bot label, if necessary.
     props-bot:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -73,6 +73,10 @@ jobs:
             ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
         steps:
+            # Note: This is not required in the example workflow, but it is here.
+            - name: Checkout repository
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
             - name: Gather a list of contributors
               # Note: this was changed to a local reference to ensure that changes within pull requests are tested
               # before merging.

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,30 +1,94 @@
-name: Test the Action
+name: Props Bot
 
 on:
-    pull_request:
+    # This event runs anytime a PR is (re)opened, updated, marked ready for review, or labeled.
+    # GitHub does not allow filtering the `labeled` event by a specific label.
+    # However, the logic below will short-circuit the workflow when the `props-bot` label is not the one being added.
+    # Note: The pull_request_target event is used instead of pull_request because this workflow needs permission to comment
+    # on the pull request. Because this event grants extra permissions to `GITHUB_TOKEN`, any code changes within the PR
+    # should be considered untrusted. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
+    pull_request_target:
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - labeled
+            - ready_for_review
+    # This event runs anytime a comment is added or deleted.
+    # You cannot filter this event for PR comments only.
+    # However, the logic below does short-circuit the workflow for issues.
+    issue_comment:
+        types:
+            - created
+    # This event will run everytime a new PR review is initially submitted.
     pull_request_review:
         types:
             - submitted
+    # This event runs anytime a PR review comment is created or deleted.
     pull_request_review_comment:
         types:
             - created
-            - deleted
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ contains( fromJSON( '["pull_request_target", "pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
-    # Tests that the Action works as expected.
+    # Compiles a list of props for a pull request.
     #
     # Performs the following steps:
-    # - Checks out the repository.
-    # - Runs the Action.
-    test:
-        name: Run Props Bot
+    # - Collects a list of contributor props and leaves a comment.
+    # - Removes the props-bot label, if necessary.
+    props-bot:
+        name: Generate a list of props
         runs-on: ubuntu-latest
+        permissions:
+            # The action needs permission `write` permission for PRs in order to add a comment.
+            pull-requests: write
+            contents: read
+        timeout-minutes: 20
+        # The job will run when pull requests are open, ready for review and:
+        #
+        # - A comment is added to the pull request.
+        # - A review is created or commented on (unless PR originates from a fork).
+        # - The pull request is opened, synchronized, marked ready for review, or reopened.
+        # - The `props-bot` label is added to the pull request.
+        if: |
+            (
+              github.event_name == 'issue_comment' && github.event.issue.pull_request ||
+              ( contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && ! github.event.pull_request.head.repo.fork ) ||
+              github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+              'props-bot' == github.event.label.name
+            ) &&
+            ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+            - name: Gather a list of contributors
+              uses: WordPress/props-bot-action@trunk
+                # Optional arguments.
+            #        with:
+            #          # Allows a custom token to be passed.
+            #          token: ${{ secrets.CUSTOM_PROPS_BOT_TOKEN }}
+            #          # Specify the prop format to display. Default is `git`. Values should be comma separated.
+            #          format: 'all'
 
-            - name: Run the Action
-              uses: ./
+            - name: Remove the props-bot label
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              if: ${{ github.event.action == 'labeled' && 'props-bot' == github.event.label.name }}
               with:
-                  format: 'all'
+                  retries: 2
+                  retry-exempt-status-codes: 418
+                  script: |
+                      github.rest.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: '${{ github.event.number }}',
+                        name: 'props-bot'
+                      });

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -4,10 +4,11 @@ on:
     # This event runs anytime a PR is (re)opened, updated, marked ready for review, or labeled.
     # GitHub does not allow filtering the `labeled` event by a specific label.
     # However, the logic below will short-circuit the workflow when the `props-bot` label is not the one being added.
-    # Note: The pull_request_target event is used instead of pull_request because this workflow needs permission to comment
-    # on the pull request. Because this event grants extra permissions to `GITHUB_TOKEN`, any code changes within the PR
-    # should be considered untrusted. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
-    pull_request_target:
+    #
+    # Note: This differs from the example workflow because code is executed from within the repository, making
+    # pull_request_target unsafe. When HEAD branches belong to forked repositories, the props-bot label should be used
+    # to ensure the list of contributors is up to date.
+    pull_request:
         types:
             - opened
             - synchronize
@@ -33,7 +34,7 @@ on:
 concurrency:
     # The concurrency group contains the workflow name and the branch name for pull requests
     # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ contains( fromJSON( '["pull_request_target", "pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && github.head_ref || github.sha }}
+    group: ${{ github.workflow }}-${{ contains( fromJSON( '["pull_request", "pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && github.head_ref || github.sha }}
     cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
@@ -60,24 +61,24 @@ jobs:
         # - A review is created or commented on (unless PR originates from a fork).
         # - The pull request is opened, synchronized, marked ready for review, or reopened.
         # - The `props-bot` label is added to the pull request.
+        #
+        # Note: pull_request_target has been replaced with pull_request for security reasons. See note above.
         if: |
             (
               github.event_name == 'issue_comment' && github.event.issue.pull_request ||
               ( contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && ! github.event.pull_request.head.repo.fork ) ||
-              github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+              github.event_name == 'pull_request' && github.event.action != 'labeled' ||
               'props-bot' == github.event.label.name
             ) &&
             ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
         steps:
             - name: Gather a list of contributors
-              uses: WordPress/props-bot-action@trunk
-                # Optional arguments.
-            #        with:
-            #          # Allows a custom token to be passed.
-            #          token: ${{ secrets.CUSTOM_PROPS_BOT_TOKEN }}
-            #          # Specify the prop format to display. Default is `git`. Values should be comma separated.
-            #          format: 'all'
+              # Note: this was changed to a local reference to ensure that changes within pull requests are tested
+              # before merging.
+              uses: ./
+              with:
+                  format: 'all'
 
             - name: Remove the props-bot label
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1


### PR DESCRIPTION
<!-- Thanks for contributing to the WordPress Props bot Action! 

All pull requests to this repository must be accompanied by an issue explaining the problem in detail. -->

## What?
This updates the workflow that runs the Props Bot action within this repository to better match the example.

## Why?
This ensures that the example in the repository is tested, and accounts for any discovered edge cases.

Currently, there's no support for the `pull_request` event `labelled` type, so the label has no affect. So there's no way to manually generate a list of props. This is important when a pull request originates from a fork.

## How?
The `./example.props-bot.yml` file has been copied into the `.github/workflows/test-action.yml` one.

A few changes have been made, each being accompanied by an inline comment that notes and explains the change for future syncs.