### PR TITLE
Parse Co-authored-by trailers in commit messages

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36799,6 +36799,7 @@ class GitHub {
 						commits(first: 100) {
 							nodes {
 								commit {
+									message
 									author {
 										user {
 											databaseId
@@ -36869,6 +36870,49 @@ class GitHub {
 	}
 
 	/**
+	 * Resolves a list of email addresses to GitHub users, where possible.
+	 *
+	 * GitHub's user search only returns accounts whose email is public, so
+	 * unresolved entries are expected and returned as null.
+	 *
+	 * @param {string[]} emails The email addresses to resolve.
+	 * @return {Promise<Object>} Map of lowercased email to user object (or null).
+	 */
+	async getUsersByEmails( emails = [] ) {
+		const result = {};
+		if ( emails.length === 0 ) {
+			return result;
+		}
+
+		const queryParts = emails.map(
+			( email, index ) =>
+				`e${ index }: search(query: "in:email ${ email.replace(
+					/"/g,
+					'\\"'
+				) }", type: USER, first: 1) { nodes { ... on User { databaseId login name email } } }`
+		);
+
+		try {
+			const data = await this.octokit.graphql(
+				'{ ' + queryParts.join( '\n' ) + ' }'
+			);
+
+			emails.forEach( ( email, index ) => {
+				const nodes = data?.[ `e${ index }` ]?.nodes || [];
+				result[ email.toLowerCase() ] =
+					nodes.length > 0 ? nodes[ 0 ] : null;
+			} );
+		} catch ( e ) {
+			core.info( `Error resolving co-author emails: ${ e.message }` );
+			emails.forEach( ( email ) => {
+				result[ email.toLowerCase() ] = null;
+			} );
+		}
+
+		return result;
+	}
+
+	/**
 	 * Adds a comment to a PR with the list of contributors.
 	 * - If a comment already exists, it will be updated.
 	 *
@@ -36912,6 +36956,20 @@ class GitHub {
 				contributorsList.unlinked.join( ', @' ) +
 				'.\n\n' +
 				'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n';
+		}
+
+		if (
+			contributorsList.unlinkedCoAuthors &&
+			contributorsList.unlinkedCoAuthors.length > 0
+		) {
+			commentMessage +=
+				'## Co-authors from commit trailers\n\n' +
+				'The following `Co-authored-by:` trailers were found in commit messages but could not be matched to a GitHub account (the email may be private):\n\n';
+			for ( const coAuthor of contributorsList.unlinkedCoAuthors ) {
+				commentMessage += `- ${ coAuthor.name } <${ coAuthor.email }>\n`;
+			}
+			commentMessage +=
+				'\nCommitters, please verify whether these contributors should be credited separately.\n\n';
 		}
 
 		if (
@@ -39190,6 +39248,36 @@ async function getWPOrgData( githubUsers ) {
 	} ).then( ( response ) => response.json() );
 }
 
+/**
+ * Parses `Co-authored-by: Name <email>` trailers from a commit message.
+ *
+ * Matches the trailer on any line, case-insensitively. Per the
+ * git-interpret-trailers convention trailers live at the end of the message,
+ * but GitHub's squash-merge flow and many commit tools write them elsewhere,
+ * so the full message is scanned.
+ *
+ * @param {string} message The commit message.
+ * @return {Array<{name: string, email: string}>} The parsed trailers.
+ */
+function parseCoAuthorTrailers( message ) {
+	if ( ! message ) {
+		return [];
+	}
+
+	const trailerRegex = /^\s*Co-authored-by:\s*(.+?)\s*<([^<>\s]+)>\s*$/gim;
+	const trailers = [];
+
+	let match;
+	while ( ( match = trailerRegex.exec( message ) ) !== null ) {
+		trailers.push( {
+			name: match[ 1 ].trim(),
+			email: match[ 2 ].trim().toLowerCase(),
+		} );
+	}
+
+	return trailers;
+}
+
 ;// CONCATENATED MODULE: ./src/contribution-collector.js
 
 
@@ -39268,6 +39356,9 @@ async function getContributorsList() {
 	// Keep track of whether the Ghostbusters are needed.
 	let hasGhostActivity = false;
 
+	// `Co-authored-by:` trailers whose email did not resolve to a GitHub user.
+	const unlinkedCoAuthors = [];
+
 	// Process pull request commits.
 	for ( const commit of contributorData?.commits?.nodes || [] ) {
 		// Set a trap for some ghosts.
@@ -39299,6 +39390,53 @@ async function getContributorsList() {
 
 	core.debug( 'Committers:' );
 	core.debug( contributors.committers );
+
+	// Collect Co-authored-by trailers from commit messages (#86).
+	const committerEmails = new Set();
+	for ( const commit of contributorData?.commits?.nodes || [] ) {
+		const authorEmail =
+			commit.commit.author?.user?.email ||
+			commit.commit.author?.email ||
+			'';
+		if ( authorEmail ) {
+			committerEmails.add( authorEmail.toLowerCase() );
+		}
+	}
+
+	const trailersByEmail = new Map();
+	for ( const commit of contributorData?.commits?.nodes || [] ) {
+		const parsed = parseCoAuthorTrailers( commit.commit?.message || '' );
+		for ( const trailer of parsed ) {
+			if ( committerEmails.has( trailer.email ) ) {
+				continue;
+			}
+			if ( ! trailersByEmail.has( trailer.email ) ) {
+				trailersByEmail.set( trailer.email, trailer );
+			}
+		}
+	}
+
+	if ( trailersByEmail.size > 0 ) {
+		core.debug( 'Co-authored-by trailers:' );
+		core.debug( [ ...trailersByEmail.values() ] );
+
+		const emailToUser = await gh.getUsersByEmails( [
+			...trailersByEmail.keys(),
+		] );
+
+		for ( const [ email, trailer ] of trailersByEmail ) {
+			const user = emailToUser[ email ];
+			if ( user?.login && ! skipUser( user.login ) ) {
+				contributors.committers.add( user.login );
+				userData[ user.login ] = user;
+			} else {
+				unlinkedCoAuthors.push( trailer );
+			}
+		}
+
+		core.debug( 'Committers (incl. co-author trailers):' );
+		core.debug( contributors.committers );
+	}
 
 	// Process pull request reviews.
 	contributorData.reviews.nodes
@@ -39452,6 +39590,9 @@ async function getContributorsList() {
 
 	// Include findings so Ghostbuster HQ can be notified.
 	contributorLists.hasGhostActivity = hasGhostActivity;
+
+	// Surface co-author trailers that couldn't be matched to a GitHub user.
+	contributorLists.unlinkedCoAuthors = unlinkedCoAuthors;
 
 	core.debug( contributorLists );
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -38939,6 +38939,39 @@ function parseCoAuthorTrailers( message ) {
 }
 
 /**
+ * Extracts the GitHub login (and numeric ID, when present) from a
+ * `users.noreply.github.com` email.
+ *
+ * Two formats exist:
+ * - `123456+login@users.noreply.github.com` (post-2017 default)
+ * - `login@users.noreply.github.com` (pre-2017)
+ *
+ * Returns null for any other email, letting the caller fall back to a
+ * GitHub user-search lookup.
+ *
+ * @param {string} email
+ * @return {{ login: string, databaseId: number|null }|null}
+ */
+function parseNoreplyEmail( email ) {
+	if ( ! email ) {
+		return null;
+	}
+
+	const match = String( email )
+		.toLowerCase()
+		.match( /^(?:(\d+)\+)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)@users\.noreply\.github\.com$/ );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	return {
+		databaseId: match[ 1 ] ? parseInt( match[ 1 ], 10 ) : null,
+		login: match[ 2 ],
+	};
+}
+
+/**
  * Escapes GitHub Flavored Markdown special characters in user-controlled text.
  *
  * Used when interpolating commit-trailer names/emails into the bot comment so
@@ -39439,17 +39472,39 @@ async function getContributorsList() {
 		core.debug( 'Co-authored-by trailers:' );
 		core.debug( [ ...trailersByEmail.values() ] );
 
-		const emailToUser = await gh.getUsersByEmails( [
-			...trailersByEmail.keys(),
-		] );
-
+		// Resolve `users.noreply.github.com` addresses locally; they encode the
+		// login directly and don't need a search call.
+		const emailsToResolve = [];
 		for ( const [ email, trailer ] of trailersByEmail ) {
-			const user = emailToUser[ email ];
-			if ( user?.login && ! skipUser( user.login ) ) {
-				contributors.committers.add( user.login );
-				userData[ user.login ] = user;
-			} else {
-				unlinkedCoAuthors.push( trailer );
+			const noreply = parseNoreplyEmail( email );
+			if ( ! noreply ) {
+				emailsToResolve.push( email );
+				continue;
+			}
+			if ( skipUser( noreply.login ) ) {
+				continue;
+			}
+			contributors.committers.add( noreply.login );
+			userData[ noreply.login ] = {
+				login: noreply.login,
+				databaseId: noreply.databaseId,
+				name: trailer.name,
+				email: trailer.email,
+			};
+		}
+
+		if ( emailsToResolve.length > 0 ) {
+			const emailToUser =
+				await gh.getUsersByEmails( emailsToResolve );
+			for ( const email of emailsToResolve ) {
+				const trailer = trailersByEmail.get( email );
+				const user = emailToUser[ email ];
+				if ( user?.login && ! skipUser( user.login ) ) {
+					contributors.committers.add( user.login );
+					userData[ user.login ] = user;
+				} else {
+					unlinkedCoAuthors.push( trailer );
+				}
 			}
 		}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -36886,10 +36886,9 @@ class GitHub {
 
 		const queryParts = emails.map(
 			( email, index ) =>
-				`e${ index }: search(query: "in:email ${ email.replace(
-					/"/g,
-					'\\"'
-				) }", type: USER, first: 1) { nodes { ... on User { databaseId login name email } } }`
+				`e${ index }: search(query: ${ JSON.stringify(
+					`in:email ${ email }`
+				) }, type: USER, first: 1) { nodes { ... on User { databaseId login name email } } }`
 		);
 
 		try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -36734,345 +36734,6 @@ var __webpack_exports__ = {};
 var core = __nccwpck_require__(7484);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
 var github = __nccwpck_require__(3228);
-;// CONCATENATED MODULE: ./src/github.js
-
-
-
-class GitHub {
-	constructor() {
-		const token =
-			core.getInput( 'token' ) || process.env.GITHUB_TOKEN || '';
-		this.octokit = github.getOctokit( token );
-
-		const formats = core.getInput( 'format' )
-			.replace( / /g, '' )
-			.split( ',' )
-			.filter( ( value ) => {
-				return value.trim();
-			} );
-
-		if ( formats.length === 0 ) {
-			this.format = [ 'git' ];
-		} else if ( formats.includes( 'all' ) ) {
-			this.format = [ 'git', 'svn' ];
-		} else if ( formats.includes( 'svn' ) || formats.includes( 'git' ) ) {
-			this.format = formats;
-		} else {
-			core.error( 'A valid props format was not provided.' );
-		}
-	}
-
-	/**
-	 * Sanitizes a string for a GraphQL query.
-	 *
-	 * @param {string} string The string to escape.
-	 * @return {string} The escaped string.
-	 */
-	escapeForGql( string ) {
-		return '_' + string.replace( /[./-]/g, '_' );
-	}
-
-	/**
-	 * Gets the contribution data for a given PR.
-	 *
-	 * Fetch the following data for the pull request:
-	 * - Commits with author details.
-	 * - Reviews with author logins.
-	 * - Comments with author logins.
-	 * - Linked issues with author logins.
-	 * - Comments on linked issues with author logins.
-	 *
-	 * @param {Object} options          The options for getting the contribution data.
-	 * @param {string} options.owner    The owner of the repository.
-	 * @param {string} options.repo     The name of the repository.
-	 * @param {number} options.prNumber The PR number.
-	 *
-	 * @return {Promise<Object>} The PR contribution data.
-	 */
-	async getContributorData( { owner, repo, prNumber } ) {
-		core.info( 'Gathering contributor list.' );
-
-		const data = await this.octokit.graphql(
-			`query($owner:String!, $name:String!, $prNumber:Int!) {
-				repository(owner:$owner, name:$name) {
-					pullRequest(number:$prNumber) {
-						commits(first: 100) {
-							nodes {
-								commit {
-									message
-									author {
-										user {
-											databaseId
-											login
-											name
-											email
-										}
-										name
-										email
-									}
-								}
-							}
-						}
-						reviews(first: 100) {
-							nodes {
-								author {
-									login
-								}
-							}
-						}
-						comments(first: 100) {
-							nodes {
-								author {
-									login
-								}
-							}
-						}
-						closingIssuesReferences(first:100){
-							nodes {
-								author {
-									login
-								}
-								comments(first:100) {
-									nodes {
-										author {
-											login
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}`,
-			{ owner, name: repo, prNumber }
-		);
-
-		return data?.repository?.pullRequest;
-	}
-
-	/**
-	 * Gets the user data for a given array of usernames.
-	 *
-	 * @param {string[]} users The array of usernames.
-	 * @return {Promise<Object>} The user data.
-	 */
-	async getUsersData( users = [] ) {
-		const userData = await this.octokit.graphql(
-			'{' +
-				users.map(
-					( user ) =>
-						this.escapeForGql( user ) +
-						`: user(login: "${ user }") {databaseId, login, name, email}`
-				) +
-				'}'
-		);
-		return userData;
-	}
-
-	/**
-	 * Resolves a list of email addresses to GitHub users, where possible.
-	 *
-	 * GitHub's user search only returns accounts whose email is public, so
-	 * unresolved entries are expected and returned as null.
-	 *
-	 * @param {string[]} emails The email addresses to resolve.
-	 * @return {Promise<Object>} Map of lowercased email to user object (or null).
-	 */
-	async getUsersByEmails( emails = [] ) {
-		const result = {};
-		if ( emails.length === 0 ) {
-			return result;
-		}
-
-		const queryParts = emails.map(
-			( email, index ) =>
-				`e${ index }: search(query: ${ JSON.stringify(
-					`in:email ${ email }`
-				) }, type: USER, first: 1) { nodes { ... on User { databaseId login name email } } }`
-		);
-
-		try {
-			const data = await this.octokit.graphql(
-				'{ ' + queryParts.join( '\n' ) + ' }'
-			);
-
-			emails.forEach( ( email, index ) => {
-				const nodes = data?.[ `e${ index }` ]?.nodes || [];
-				result[ email.toLowerCase() ] =
-					nodes.length > 0 ? nodes[ 0 ] : null;
-			} );
-		} catch ( e ) {
-			core.info( `Error resolving co-author emails: ${ e.message }` );
-			emails.forEach( ( email ) => {
-				result[ email.toLowerCase() ] = null;
-			} );
-		}
-
-		return result;
-	}
-
-	/**
-	 * Adds a comment to a PR with the list of contributors.
-	 * - If a comment already exists, it will be updated.
-	 *
-	 * @param {Object} options                  The options for commenting.
-	 * @param {Object} options.context          The context object containing information about the GitHub event.
-	 * @param {Array}  options.contributorsList The list of contributors.
-	 *
-	 * @return {Promise<void>} - A promise that resolves when the comment is posted.
-	 */
-	async commentProps( { context, contributorsList } ) {
-		if ( ! contributorsList ) {
-			core.info( 'No contributors were provided.' );
-			return;
-		}
-
-		core.debug( 'Contributor list received:' );
-		core.debug( contributorsList );
-
-		core.debug( 'Formats requested:' );
-		core.debug( this.format );
-
-		let prNumber = context.payload?.pull_request?.number;
-		if ( 'issue_comment' === context.eventName ) {
-			prNumber = context.payload?.issue?.number;
-		}
-
-		let commentId;
-		const commentInfo = {
-			owner: context.repo.owner,
-			repo: context.repo.repo,
-			issue_number: prNumber,
-		};
-
-		let commentMessage =
-			'The following accounts have interacted with this PR and/or linked issues. I will continue to update these lists as activity occurs. You can also manually ask me to refresh this list by adding the `props-bot` label.\n\n';
-
-		if ( contributorsList.unlinked.length > 0 ) {
-			commentMessage +=
-				'## Unlinked Accounts\n\n' +
-				'The following contributors have not linked their GitHub and WordPress.org accounts: @' +
-				contributorsList.unlinked.join( ', @' ) +
-				'.\n\n' +
-				'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n';
-		}
-
-		if (
-			contributorsList.unlinkedCoAuthors &&
-			contributorsList.unlinkedCoAuthors.length > 0
-		) {
-			commentMessage +=
-				'## Co-authors from commit trailers\n\n' +
-				'The following `Co-authored-by:` trailers were found in commit messages but could not be matched to a GitHub account (the email may be private):\n\n';
-			for ( const coAuthor of contributorsList.unlinkedCoAuthors ) {
-				commentMessage += `- ${ coAuthor.name } <${ coAuthor.email }>\n`;
-			}
-			commentMessage +=
-				'\nCommitters, please verify whether these contributors should be credited separately.\n\n';
-		}
-
-		if (
-			this.format.includes( 'svn' ) &&
-			contributorsList.svn.length > 0
-		) {
-			if ( this.format.includes( 'git' ) ) {
-				commentMessage += '## Core SVN\n\n';
-			}
-
-			commentMessage +=
-				'Core Committers: Use this line as a base for the props when committing in SVN:\n' +
-				'```\n' +
-				'Props ' +
-				contributorsList.svn.join( ', ' ) +
-				'.' +
-				'\n```\n\n';
-		}
-
-		if ( this.format.includes( 'git' ) ) {
-			if ( this.format.includes( 'svn' ) ) {
-				commentMessage += '## GitHub Merge commits\n\n';
-			}
-
-			commentMessage +=
-				"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
-				'```\n';
-
-			if ( contributorsList.unlinked.length > 0 ) {
-				commentMessage +=
-					'Unlinked contributors: ' +
-					contributorsList.unlinked.join( ', ' ) +
-					'.\n\n';
-			}
-
-			if ( contributorsList.coAuthored.length > 0 ) {
-				commentMessage += contributorsList.coAuthored.join( '\n' );
-			}
-
-			commentMessage += '\n```\n\n';
-		}
-
-		// Note that ghosts were detected. Spooky! 👻
-		if ( contributorsList.hasGhostActivity ) {
-			commentMessage +=
-				'At least one `ghost` was discovered. `ghost`s represent deleted GitHub user accounts.\n\n';
-		}
-
-		commentMessage +=
-			"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
-
-		const comment = {
-			...commentInfo,
-			body: commentMessage,
-		};
-
-		for await ( const response of this.octokit.paginate.iterator(
-			this.octokit.rest.issues.listComments,
-			commentInfo
-		) ) {
-			for ( const currentComment of response.data ) {
-				if (
-					currentComment.user.type === 'Bot' &&
-					currentComment.body.includes(
-						'The following accounts have interacted with this PR and/or linked issues.'
-					)
-				) {
-					commentId = currentComment.id;
-					break;
-				}
-			}
-
-			if ( commentId ) {
-				break;
-			}
-		}
-
-		if ( commentId ) {
-			core.info( `Updating previous comment #${ commentId }` );
-
-			try {
-				await this.octokit.rest.issues.updateComment( {
-					...context.repo,
-					comment_id: commentId,
-					body: comment.body,
-				} );
-			} catch ( e ) {
-				core.info( 'Error editing previous comment: ' + e.message );
-				commentId = null;
-			}
-		}
-
-		// No previous or edit comment failed.
-		if ( ! commentId ) {
-			core.info( 'No previous comment found. Creating a new one.' );
-			try {
-				await this.octokit.rest.issues.createComment( comment );
-			} catch ( e ) {
-				core.error( `Error creating comment: ${ e.message }` );
-			}
-		}
-	}
-}
-
 ;// CONCATENATED MODULE: external "node:http"
 const external_node_http_namespaceObject = require("node:http");
 ;// CONCATENATED MODULE: external "node:https"
@@ -39275,6 +38936,365 @@ function parseCoAuthorTrailers( message ) {
 	}
 
 	return trailers;
+}
+
+/**
+ * Escapes GitHub Flavored Markdown special characters in user-controlled text.
+ *
+ * Used when interpolating commit-trailer names/emails into the bot comment so
+ * they cannot inject links, `@`-mentions, or other markdown into a bot-authored
+ * PR comment.
+ *
+ * @param {string} text The text to escape.
+ * @return {string} The escaped text.
+ */
+function escapeMarkdown( text ) {
+	return String( text ?? '' ).replace(
+		/([\\`*_{}[\]()<>#+\-.!|@~])/g,
+		'\\$1'
+	);
+}
+
+;// CONCATENATED MODULE: ./src/github.js
+
+
+
+
+class GitHub {
+	constructor() {
+		const token =
+			core.getInput( 'token' ) || process.env.GITHUB_TOKEN || '';
+		this.octokit = github.getOctokit( token );
+
+		const formats = core.getInput( 'format' )
+			.replace( / /g, '' )
+			.split( ',' )
+			.filter( ( value ) => {
+				return value.trim();
+			} );
+
+		if ( formats.length === 0 ) {
+			this.format = [ 'git' ];
+		} else if ( formats.includes( 'all' ) ) {
+			this.format = [ 'git', 'svn' ];
+		} else if ( formats.includes( 'svn' ) || formats.includes( 'git' ) ) {
+			this.format = formats;
+		} else {
+			core.error( 'A valid props format was not provided.' );
+		}
+	}
+
+	/**
+	 * Sanitizes a string for a GraphQL query.
+	 *
+	 * @param {string} string The string to escape.
+	 * @return {string} The escaped string.
+	 */
+	escapeForGql( string ) {
+		return '_' + string.replace( /[./-]/g, '_' );
+	}
+
+	/**
+	 * Gets the contribution data for a given PR.
+	 *
+	 * Fetch the following data for the pull request:
+	 * - Commits with author details.
+	 * - Reviews with author logins.
+	 * - Comments with author logins.
+	 * - Linked issues with author logins.
+	 * - Comments on linked issues with author logins.
+	 *
+	 * @param {Object} options          The options for getting the contribution data.
+	 * @param {string} options.owner    The owner of the repository.
+	 * @param {string} options.repo     The name of the repository.
+	 * @param {number} options.prNumber The PR number.
+	 *
+	 * @return {Promise<Object>} The PR contribution data.
+	 */
+	async getContributorData( { owner, repo, prNumber } ) {
+		core.info( 'Gathering contributor list.' );
+
+		const data = await this.octokit.graphql(
+			`query($owner:String!, $name:String!, $prNumber:Int!) {
+				repository(owner:$owner, name:$name) {
+					pullRequest(number:$prNumber) {
+						commits(first: 100) {
+							nodes {
+								commit {
+									message
+									author {
+										user {
+											databaseId
+											login
+											name
+											email
+										}
+										name
+										email
+									}
+								}
+							}
+						}
+						reviews(first: 100) {
+							nodes {
+								author {
+									login
+								}
+							}
+						}
+						comments(first: 100) {
+							nodes {
+								author {
+									login
+								}
+							}
+						}
+						closingIssuesReferences(first:100){
+							nodes {
+								author {
+									login
+								}
+								comments(first:100) {
+									nodes {
+										author {
+											login
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}`,
+			{ owner, name: repo, prNumber }
+		);
+
+		return data?.repository?.pullRequest;
+	}
+
+	/**
+	 * Gets the user data for a given array of usernames.
+	 *
+	 * @param {string[]} users The array of usernames.
+	 * @return {Promise<Object>} The user data.
+	 */
+	async getUsersData( users = [] ) {
+		const userData = await this.octokit.graphql(
+			'{' +
+				users.map(
+					( user ) =>
+						this.escapeForGql( user ) +
+						`: user(login: "${ user }") {databaseId, login, name, email}`
+				) +
+				'}'
+		);
+		return userData;
+	}
+
+	/**
+	 * Resolves a list of email addresses to GitHub users, where possible.
+	 *
+	 * GitHub's user search only returns accounts whose email is public, so
+	 * unresolved entries are expected and returned as null.
+	 *
+	 * @param {string[]} emails The email addresses to resolve.
+	 * @return {Promise<Object>} Map of lowercased email to user object (or null).
+	 */
+	async getUsersByEmails( emails = [] ) {
+		const result = {};
+		if ( emails.length === 0 ) {
+			return result;
+		}
+
+		const queryParts = emails.map(
+			( email, index ) =>
+				`e${ index }: search(query: ${ JSON.stringify(
+					`in:email ${ email }`
+				) }, type: USER, first: 1) { nodes { ... on User { databaseId login name email } } }`
+		);
+
+		try {
+			const data = await this.octokit.graphql(
+				'{ ' + queryParts.join( '\n' ) + ' }'
+			);
+
+			emails.forEach( ( email, index ) => {
+				const nodes = data?.[ `e${ index }` ]?.nodes || [];
+				result[ email.toLowerCase() ] =
+					nodes.length > 0 ? nodes[ 0 ] : null;
+			} );
+		} catch ( e ) {
+			core.warning( `Error resolving co-author emails: ${ e.message }` );
+			emails.forEach( ( email ) => {
+				result[ email.toLowerCase() ] = null;
+			} );
+		}
+
+		return result;
+	}
+
+	/**
+	 * Adds a comment to a PR with the list of contributors.
+	 * - If a comment already exists, it will be updated.
+	 *
+	 * @param {Object} options                  The options for commenting.
+	 * @param {Object} options.context          The context object containing information about the GitHub event.
+	 * @param {Array}  options.contributorsList The list of contributors.
+	 *
+	 * @return {Promise<void>} - A promise that resolves when the comment is posted.
+	 */
+	async commentProps( { context, contributorsList } ) {
+		if ( ! contributorsList ) {
+			core.info( 'No contributors were provided.' );
+			return;
+		}
+
+		core.debug( 'Contributor list received:' );
+		core.debug( contributorsList );
+
+		core.debug( 'Formats requested:' );
+		core.debug( this.format );
+
+		let prNumber = context.payload?.pull_request?.number;
+		if ( 'issue_comment' === context.eventName ) {
+			prNumber = context.payload?.issue?.number;
+		}
+
+		let commentId;
+		const commentInfo = {
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			issue_number: prNumber,
+		};
+
+		let commentMessage =
+			'The following accounts have interacted with this PR and/or linked issues. I will continue to update these lists as activity occurs. You can also manually ask me to refresh this list by adding the `props-bot` label.\n\n';
+
+		if ( contributorsList.unlinked.length > 0 ) {
+			commentMessage +=
+				'## Unlinked Accounts\n\n' +
+				'The following contributors have not linked their GitHub and WordPress.org accounts: @' +
+				contributorsList.unlinked.join( ', @' ) +
+				'.\n\n' +
+				'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n';
+		}
+
+		if (
+			contributorsList.unlinkedCoAuthors &&
+			contributorsList.unlinkedCoAuthors.length > 0
+		) {
+			commentMessage +=
+				'## Co-authors from commit trailers\n\n' +
+				'The following `Co-authored-by:` trailers were found in commit messages but could not be matched to a GitHub account (the email may be private):\n\n';
+			for ( const coAuthor of contributorsList.unlinkedCoAuthors ) {
+				commentMessage += `- ${ escapeMarkdown(
+					coAuthor.name
+				) } <${ escapeMarkdown( coAuthor.email ) }>\n`;
+			}
+			commentMessage +=
+				'\nCommitters, please verify whether these contributors should be credited separately.\n\n';
+		}
+
+		if (
+			this.format.includes( 'svn' ) &&
+			contributorsList.svn.length > 0
+		) {
+			if ( this.format.includes( 'git' ) ) {
+				commentMessage += '## Core SVN\n\n';
+			}
+
+			commentMessage +=
+				'Core Committers: Use this line as a base for the props when committing in SVN:\n' +
+				'```\n' +
+				'Props ' +
+				contributorsList.svn.join( ', ' ) +
+				'.' +
+				'\n```\n\n';
+		}
+
+		if ( this.format.includes( 'git' ) ) {
+			if ( this.format.includes( 'svn' ) ) {
+				commentMessage += '## GitHub Merge commits\n\n';
+			}
+
+			commentMessage +=
+				"If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.\n\n" +
+				'```\n';
+
+			if ( contributorsList.unlinked.length > 0 ) {
+				commentMessage +=
+					'Unlinked contributors: ' +
+					contributorsList.unlinked.join( ', ' ) +
+					'.\n\n';
+			}
+
+			if ( contributorsList.coAuthored.length > 0 ) {
+				commentMessage += contributorsList.coAuthored.join( '\n' );
+			}
+
+			commentMessage += '\n```\n\n';
+		}
+
+		// Note that ghosts were detected. Spooky! 👻
+		if ( contributorsList.hasGhostActivity ) {
+			commentMessage +=
+				'At least one `ghost` was discovered. `ghost`s represent deleted GitHub user accounts.\n\n';
+		}
+
+		commentMessage +=
+			"**To understand the WordPress project's expectations around crediting contributors, please [review the Contributor Attribution page in the Core Handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/).**\n";
+
+		const comment = {
+			...commentInfo,
+			body: commentMessage,
+		};
+
+		for await ( const response of this.octokit.paginate.iterator(
+			this.octokit.rest.issues.listComments,
+			commentInfo
+		) ) {
+			for ( const currentComment of response.data ) {
+				if (
+					currentComment.user.type === 'Bot' &&
+					currentComment.body.includes(
+						'The following accounts have interacted with this PR and/or linked issues.'
+					)
+				) {
+					commentId = currentComment.id;
+					break;
+				}
+			}
+
+			if ( commentId ) {
+				break;
+			}
+		}
+
+		if ( commentId ) {
+			core.info( `Updating previous comment #${ commentId }` );
+
+			try {
+				await this.octokit.rest.issues.updateComment( {
+					...context.repo,
+					comment_id: commentId,
+					body: comment.body,
+				} );
+			} catch ( e ) {
+				core.info( 'Error editing previous comment: ' + e.message );
+				commentId = null;
+			}
+		}
+
+		// No previous or edit comment failed.
+		if ( ! commentId ) {
+			core.info( 'No previous comment found. Creating a new one.' );
+			try {
+				await this.octokit.rest.issues.createComment( comment );
+			} catch ( e ) {
+				core.error( `Error creating comment: ${ e.message }` );
+			}
+		}
+	}
 }
 
 ;// CONCATENATED MODULE: ./src/contribution-collector.js

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import GitHub from './github.js';
-import { getWPOrgData } from './utils.js';
+import { getWPOrgData, parseCoAuthorTrailers } from './utils.js';
 
 const { context } = github;
 const gh = new GitHub();
@@ -75,6 +75,9 @@ export async function getContributorsList() {
 	// Keep track of whether the Ghostbusters are needed.
 	let hasGhostActivity = false;
 
+	// `Co-authored-by:` trailers whose email did not resolve to a GitHub user.
+	const unlinkedCoAuthors = [];
+
 	// Process pull request commits.
 	for ( const commit of contributorData?.commits?.nodes || [] ) {
 		// Set a trap for some ghosts.
@@ -106,6 +109,53 @@ export async function getContributorsList() {
 
 	core.debug( 'Committers:' );
 	core.debug( contributors.committers );
+
+	// Collect Co-authored-by trailers from commit messages (#86).
+	const committerEmails = new Set();
+	for ( const commit of contributorData?.commits?.nodes || [] ) {
+		const authorEmail =
+			commit.commit.author?.user?.email ||
+			commit.commit.author?.email ||
+			'';
+		if ( authorEmail ) {
+			committerEmails.add( authorEmail.toLowerCase() );
+		}
+	}
+
+	const trailersByEmail = new Map();
+	for ( const commit of contributorData?.commits?.nodes || [] ) {
+		const parsed = parseCoAuthorTrailers( commit.commit?.message || '' );
+		for ( const trailer of parsed ) {
+			if ( committerEmails.has( trailer.email ) ) {
+				continue;
+			}
+			if ( ! trailersByEmail.has( trailer.email ) ) {
+				trailersByEmail.set( trailer.email, trailer );
+			}
+		}
+	}
+
+	if ( trailersByEmail.size > 0 ) {
+		core.debug( 'Co-authored-by trailers:' );
+		core.debug( [ ...trailersByEmail.values() ] );
+
+		const emailToUser = await gh.getUsersByEmails( [
+			...trailersByEmail.keys(),
+		] );
+
+		for ( const [ email, trailer ] of trailersByEmail ) {
+			const user = emailToUser[ email ];
+			if ( user?.login && ! skipUser( user.login ) ) {
+				contributors.committers.add( user.login );
+				userData[ user.login ] = user;
+			} else {
+				unlinkedCoAuthors.push( trailer );
+			}
+		}
+
+		core.debug( 'Committers (incl. co-author trailers):' );
+		core.debug( contributors.committers );
+	}
 
 	// Process pull request reviews.
 	contributorData.reviews.nodes
@@ -259,6 +309,9 @@ export async function getContributorsList() {
 
 	// Include findings so Ghostbuster HQ can be notified.
 	contributorLists.hasGhostActivity = hasGhostActivity;
+
+	// Surface co-author trailers that couldn't be matched to a GitHub user.
+	contributorLists.unlinkedCoAuthors = unlinkedCoAuthors;
 
 	core.debug( contributorLists );
 

--- a/src/contribution-collector.js
+++ b/src/contribution-collector.js
@@ -1,7 +1,11 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import GitHub from './github.js';
-import { getWPOrgData, parseCoAuthorTrailers } from './utils.js';
+import {
+	getWPOrgData,
+	parseCoAuthorTrailers,
+	parseNoreplyEmail,
+} from './utils.js';
 
 const { context } = github;
 const gh = new GitHub();
@@ -139,17 +143,39 @@ export async function getContributorsList() {
 		core.debug( 'Co-authored-by trailers:' );
 		core.debug( [ ...trailersByEmail.values() ] );
 
-		const emailToUser = await gh.getUsersByEmails( [
-			...trailersByEmail.keys(),
-		] );
-
+		// Resolve `users.noreply.github.com` addresses locally; they encode the
+		// login directly and don't need a search call.
+		const emailsToResolve = [];
 		for ( const [ email, trailer ] of trailersByEmail ) {
-			const user = emailToUser[ email ];
-			if ( user?.login && ! skipUser( user.login ) ) {
-				contributors.committers.add( user.login );
-				userData[ user.login ] = user;
-			} else {
-				unlinkedCoAuthors.push( trailer );
+			const noreply = parseNoreplyEmail( email );
+			if ( ! noreply ) {
+				emailsToResolve.push( email );
+				continue;
+			}
+			if ( skipUser( noreply.login ) ) {
+				continue;
+			}
+			contributors.committers.add( noreply.login );
+			userData[ noreply.login ] = {
+				login: noreply.login,
+				databaseId: noreply.databaseId,
+				name: trailer.name,
+				email: trailer.email,
+			};
+		}
+
+		if ( emailsToResolve.length > 0 ) {
+			const emailToUser =
+				await gh.getUsersByEmails( emailsToResolve );
+			for ( const email of emailsToResolve ) {
+				const trailer = trailersByEmail.get( email );
+				const user = emailToUser[ email ];
+				if ( user?.login && ! skipUser( user.login ) ) {
+					contributors.committers.add( user.login );
+					userData[ user.login ] = user;
+				} else {
+					unlinkedCoAuthors.push( trailer );
+				}
 			}
 		}
 

--- a/src/github.js
+++ b/src/github.js
@@ -1,5 +1,6 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
+import { escapeMarkdown } from './utils.js';
 
 export default class GitHub {
 	constructor() {
@@ -166,7 +167,7 @@ export default class GitHub {
 					nodes.length > 0 ? nodes[ 0 ] : null;
 			} );
 		} catch ( e ) {
-			core.info( `Error resolving co-author emails: ${ e.message }` );
+			core.warning( `Error resolving co-author emails: ${ e.message }` );
 			emails.forEach( ( email ) => {
 				result[ email.toLowerCase() ] = null;
 			} );
@@ -229,7 +230,9 @@ export default class GitHub {
 				'## Co-authors from commit trailers\n\n' +
 				'The following `Co-authored-by:` trailers were found in commit messages but could not be matched to a GitHub account (the email may be private):\n\n';
 			for ( const coAuthor of contributorsList.unlinkedCoAuthors ) {
-				commentMessage += `- ${ coAuthor.name } <${ coAuthor.email }>\n`;
+				commentMessage += `- ${ escapeMarkdown(
+					coAuthor.name
+				) } <${ escapeMarkdown( coAuthor.email ) }>\n`;
 			}
 			commentMessage +=
 				'\nCommitters, please verify whether these contributors should be credited separately.\n\n';

--- a/src/github.js
+++ b/src/github.js
@@ -63,6 +63,7 @@ export default class GitHub {
 						commits(first: 100) {
 							nodes {
 								commit {
+									message
 									author {
 										user {
 											databaseId
@@ -133,6 +134,49 @@ export default class GitHub {
 	}
 
 	/**
+	 * Resolves a list of email addresses to GitHub users, where possible.
+	 *
+	 * GitHub's user search only returns accounts whose email is public, so
+	 * unresolved entries are expected and returned as null.
+	 *
+	 * @param {string[]} emails The email addresses to resolve.
+	 * @return {Promise<Object>} Map of lowercased email to user object (or null).
+	 */
+	async getUsersByEmails( emails = [] ) {
+		const result = {};
+		if ( emails.length === 0 ) {
+			return result;
+		}
+
+		const queryParts = emails.map(
+			( email, index ) =>
+				`e${ index }: search(query: "in:email ${ email.replace(
+					/"/g,
+					'\\"'
+				) }", type: USER, first: 1) { nodes { ... on User { databaseId login name email } } }`
+		);
+
+		try {
+			const data = await this.octokit.graphql(
+				'{ ' + queryParts.join( '\n' ) + ' }'
+			);
+
+			emails.forEach( ( email, index ) => {
+				const nodes = data?.[ `e${ index }` ]?.nodes || [];
+				result[ email.toLowerCase() ] =
+					nodes.length > 0 ? nodes[ 0 ] : null;
+			} );
+		} catch ( e ) {
+			core.info( `Error resolving co-author emails: ${ e.message }` );
+			emails.forEach( ( email ) => {
+				result[ email.toLowerCase() ] = null;
+			} );
+		}
+
+		return result;
+	}
+
+	/**
 	 * Adds a comment to a PR with the list of contributors.
 	 * - If a comment already exists, it will be updated.
 	 *
@@ -176,6 +220,20 @@ export default class GitHub {
 				contributorsList.unlinked.join( ', @' ) +
 				'.\n\n' +
 				'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/) to ensure your work is properly credited in WordPress releases.\n\n';
+		}
+
+		if (
+			contributorsList.unlinkedCoAuthors &&
+			contributorsList.unlinkedCoAuthors.length > 0
+		) {
+			commentMessage +=
+				'## Co-authors from commit trailers\n\n' +
+				'The following `Co-authored-by:` trailers were found in commit messages but could not be matched to a GitHub account (the email may be private):\n\n';
+			for ( const coAuthor of contributorsList.unlinkedCoAuthors ) {
+				commentMessage += `- ${ coAuthor.name } <${ coAuthor.email }>\n`;
+			}
+			commentMessage +=
+				'\nCommitters, please verify whether these contributors should be credited separately.\n\n';
 		}
 
 		if (

--- a/src/github.js
+++ b/src/github.js
@@ -150,10 +150,9 @@ export default class GitHub {
 
 		const queryParts = emails.map(
 			( email, index ) =>
-				`e${ index }: search(query: "in:email ${ email.replace(
-					/"/g,
-					'\\"'
-				) }", type: USER, first: 1) { nodes { ... on User { databaseId login name email } } }`
+				`e${ index }: search(query: ${ JSON.stringify(
+					`in:email ${ email }`
+				) }, type: USER, first: 1) { nodes { ... on User { databaseId login name email } } }`
 		);
 
 		try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,6 +57,39 @@ export function parseCoAuthorTrailers( message ) {
 }
 
 /**
+ * Extracts the GitHub login (and numeric ID, when present) from a
+ * `users.noreply.github.com` email.
+ *
+ * Two formats exist:
+ * - `123456+login@users.noreply.github.com` (post-2017 default)
+ * - `login@users.noreply.github.com` (pre-2017)
+ *
+ * Returns null for any other email, letting the caller fall back to a
+ * GitHub user-search lookup.
+ *
+ * @param {string} email
+ * @return {{ login: string, databaseId: number|null }|null}
+ */
+export function parseNoreplyEmail( email ) {
+	if ( ! email ) {
+		return null;
+	}
+
+	const match = String( email )
+		.toLowerCase()
+		.match( /^(?:(\d+)\+)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)@users\.noreply\.github\.com$/ );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	return {
+		databaseId: match[ 1 ] ? parseInt( match[ 1 ], 10 ) : null,
+		login: match[ 2 ],
+	};
+}
+
+/**
  * Escapes GitHub Flavored Markdown special characters in user-controlled text.
  *
  * Used when interpolating commit-trailer names/emails into the bot comment so

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,3 +55,20 @@ export function parseCoAuthorTrailers( message ) {
 
 	return trailers;
 }
+
+/**
+ * Escapes GitHub Flavored Markdown special characters in user-controlled text.
+ *
+ * Used when interpolating commit-trailer names/emails into the bot comment so
+ * they cannot inject links, `@`-mentions, or other markdown into a bot-authored
+ * PR comment.
+ *
+ * @param {string} text The text to escape.
+ * @return {string} The escaped text.
+ */
+export function escapeMarkdown( text ) {
+	return String( text ?? '' ).replace(
+		/([\\`*_{}[\]()<>#+\-.!|@~])/g,
+		'\\$1'
+	);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,3 +25,33 @@ export async function getWPOrgData( githubUsers ) {
 		body: JSON.stringify( { github_user: githubUsers } ),
 	} ).then( ( response ) => response.json() );
 }
+
+/**
+ * Parses `Co-authored-by: Name <email>` trailers from a commit message.
+ *
+ * Matches the trailer on any line, case-insensitively. Per the
+ * git-interpret-trailers convention trailers live at the end of the message,
+ * but GitHub's squash-merge flow and many commit tools write them elsewhere,
+ * so the full message is scanned.
+ *
+ * @param {string} message The commit message.
+ * @return {Array<{name: string, email: string}>} The parsed trailers.
+ */
+export function parseCoAuthorTrailers( message ) {
+	if ( ! message ) {
+		return [];
+	}
+
+	const trailerRegex = /^\s*Co-authored-by:\s*(.+?)\s*<([^<>\s]+)>\s*$/gim;
+	const trailers = [];
+
+	let match;
+	while ( ( match = trailerRegex.exec( message ) ) !== null ) {
+		trailers.push( {
+			name: match[ 1 ].trim(),
+			email: match[ 2 ].trim().toLowerCase(),
+		} );
+	}
+
+	return trailers;
+}


### PR DESCRIPTION
## What?

Parses `Co-authored-by:` trailers from PR commit messages so co-authors show up in the props output.

Fixes #86

## Why?

Today the action only credits the direct commit author; any `Co-authored-by:` trailers in the commit message are ignored. That silently drops contributors from both the SVN props line and the Git co-authored-by block — especially painful when the PR is committed to SVN, where the full list is the authoritative record.

Per desrosj's comment on #86, parsing trailers and including them (SVN in particular) is the sensible first step, with the Git-side nuance handled by the existing squash-merge trailer behavior plus dedupe.

## How?

- **`src/utils.js`** — new `parseCoAuthorTrailers(message)` helper. Case-insensitive regex scan of the whole message returning `{ name, email }` pairs. Emails lowercased for dedupe. Also adds a small `escapeMarkdown(text)` helper for safely interpolating attacker-controllable trailer text into the bot comment.
- **`src/github.js::getContributorData`** — adds `message` to the GraphQL commit query.
- **`src/github.js::getUsersByEmails`** — new method. Batch-resolves emails to GitHub users via a single GraphQL query with aliased `search(type: USER, query: "in:email …")` calls. The query value is built with `JSON.stringify` so backslashes, quotes, and control chars in trailer emails can't break out of the GraphQL string literal. On API failure the error is logged via `core.warning` and every email falls through as unresolved.
- **`src/contribution-collector.js`** — after the normal commits loop, extracts trailers, dedupes against committer emails (so a PR author self-crediting doesn't double-count), and resolves via `getUsersByEmails`. Resolved trailer authors flow through the existing committer path (WPORG lookup, standard dedupe, SVN + Git formatting). Unresolved trailers land in a new `unlinkedCoAuthors` list on the output.
- **`src/github.js::commentProps`** — renders unresolved trailers in a new "Co-authors from commit trailers" section (shown just after "Unlinked Accounts") so committers can credit them manually. Name and email are passed through `escapeMarkdown` so crafted trailers can't inject links, images, or `@`-mentions into a bot-authored comment. Unresolved entries do not enter the Git co-authored-by block, avoiding double-counting when the trailer is already in the squash-merge commit.
- **`dist/index.js`** — rebuilt via `ncc`.

## Testing Instructions

1. Open a test PR against this action with commits that include a mix of trailers:
   - A trailer whose email is public on GitHub → contributor should appear in the committer list, SVN props, and Git co-authored-by block just like a direct committer.
   - A trailer with a private or unknown email (e.g. a `…@users.noreply.github.com` where the GitHub user has no public email) → should appear in the new "Co-authors from commit trailers" section of the props-bot comment.
   - A trailer matching the PR author's own email → should be deduped (not double-counted anywhere).
   - A trailer with markdown special characters in the name (e.g. `Co-authored-by: [click me](https://evil.test) @octocat <foo@example.com>` where `foo@example.com` isn't public) → the unresolved entry in the bot comment should render the bracketed text and `@octocat` literally, not as a link or mention.
2. Confirm the props-bot comment renders each case.
3. Open an unrelated PR with no trailers → no regressions, no new section appears.