### PR TITLE
Clarify the required permissions for the GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ For a full breakdown of the WordPress project's Props best practices, please con
 | `token`  | `$GITHUB_TOKEN` | GitHub token with permission to comment on the pull request.                                                                            |
 | `format` | `git`           | The style of contributor lists to include. Accepted values are `svn`, `git`, or `all`, or any combination of those separated by commas. |
 
+## Permissions
+
+The calling workflow must grant the following permissions to `GITHUB_TOKEN`:
+
+### Public repos
+
+```yaml
+permissions:
+  pull-requests: write # Needed to post the props comment to the PR.
+```
+
+### Private repos
+
+```yaml
+permissions:
+  pull-requests: write # Needed to post the props comment to the PR.
+  issues: read         # Needed to read comments on issues linked to the PR.
+```
+
 ## Example Workflow File
 
 To get started, copy and commit the [`example-props-bot.yml` file](https://github.com/WordPress/props-bot-action/blob/trunk/example-props-bot.yml) into the `.github/workflows` directory of your project's repository.

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
         required: false
         default: 'git'
     token:
-        description: 'GitHub secret token.'
+        description: 'GitHub token. Requires `pull-requests: write` permission. On a private repo it additionally needs `issues: read` permission.'
         required: true
         default: ${{ github.token }}
 runs:

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
         required: false
         default: 'git'
     token:
-        description: 'GitHub token. Requires `pull-requests: write` permission. On a private repo it additionally needs `issues: read` permission.'
+        description: 'GitHub token. Requires `pull-requests: write` permission. On a private repo it additionally requires `issues: read` permission.'
         required: true
         default: ${{ github.token }}
 runs:

--- a/example-props-bot.yml
+++ b/example-props-bot.yml
@@ -50,9 +50,8 @@ jobs:
         name: Generate a list of props
         runs-on: ubuntu-latest
         permissions:
-            # The action needs permission `write` permission for PRs in order to add a comment.
+            # The action needs `write` permission for PRs in order to add a comment.
             pull-requests: write
-            contents: read
         timeout-minutes: 20
         # The job will run when pull requests are open, ready for review and:
         #


### PR DESCRIPTION
## What?

This clarifies the minimal permissions that this action requires to operate.

## Why?

In order for a consuming repo to tighten up the permissions it grants to tokens used by other actions, clear docs are required.

## How?

I used some public and private test repos to test the permissions required for this action. On a public repo, only `pull-requests: write` is needed to comment on the PR. On a private repo, `issues: read` is additionally needed to read comments on linked issues.

`contents: read` isn't needed because the action doesn't check out the consuming repo or read any files from it.

## Testing Instructions

1. Update a calling workflow with the documented permissions
2. Ensure nothing breaks